### PR TITLE
PHPCS configuration

### DIFF
--- a/.ddev/commands/web/phpcbf
+++ b/.ddev/commands/web/phpcbf
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Run the PHP Code Fixer against the codebase. See phpcs.xml in the project
+# root for configuration settings.
+
+phpcbf "$@"

--- a/.ddev/commands/web/phpcbf
+++ b/.ddev/commands/web/phpcbf
@@ -3,4 +3,4 @@
 # Run the PHP Code Fixer against the codebase. See phpcs.xml in the project
 # root for configuration settings.
 
-phpcbf "$@"
+phpcbf --standard=phpcs.xml "$@"

--- a/.ddev/commands/web/phpcs
+++ b/.ddev/commands/web/phpcs
@@ -3,4 +3,4 @@
 # Run the PHP Code Sniffer against the codebase. See phpcs.xml in the project
 # root for configuration settings.
 
-phpcs "$@"
+phpcs --standard=phpcs.xml "$@"

--- a/.ddev/commands/web/phpcs
+++ b/.ddev/commands/web/phpcs
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Run the PHP Code Sniffer against the codebase. See phpcs.xml in the project
+# root for configuration settings.
+
+phpcs "$@"

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
             "url": "https://packages.drupal.org/8"
         }
     ],
+    "scripts": {
+        "phpcs": "phpcs --standard=phpcs.xml"
+    },
     "require": {
         "composer/installers": "^2.0",
         "cweagans/composer-patches": "^1.7",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,12 +10,12 @@
   <!-- If you have Coder installed locally then you can reference the Drupal
   standards with relative paths. Otherwise simply use "Drupal" and
   "DrupalPractice. -->
-  <rule ref="../vendor/drupal/coder/coder_sniffer/Drupal">
+  <rule ref="vendor/drupal/coder/coder_sniffer/Drupal">
     <!-- Example how you would disable a rule you are not compliant with yet:
     <exclude name="Drupal.Commenting.Deprecated"/>
     -->
   </rule>
-  <rule ref="../vendor/drupal/coder/coder_sniffer/DrupalPractice"/>
+  <rule ref="vendor/drupal/coder/coder_sniffer/DrupalPractice"/>
 
   <!-- Example how you would disable an external rule you do not like:
   <rule ref="PEAR.Functions.ValidDefaultValue.NotAtEnd">

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="drupal">
-  <description>PHP CodeSniffer configuration for example development.</description>
-  <!-- Check all files in the current directory and below. -->
-  <file>.</file>
+  <description>PHP CodeSniffer configuration for development.</description>
+  <!-- Specify folders. -->
+  <file>web/modules/custom</file>
+  <!-- <file>web/profiles/custom</file> -->
+  <!-- <file>web/themes/custom</file> -->
+
   <arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt,md,yml"/>
   <!-- Change this value to 7 if you want to check Drupal 7 code. -->
   <config name="drupal_core_version" value="10"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="drupal">
+  <description>PHP CodeSniffer configuration for example development.</description>
+  <!-- Check all files in the current directory and below. -->
+  <file>.</file>
+  <arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt,md,yml"/>
+  <!-- Change this value to 7 if you want to check Drupal 7 code. -->
+  <config name="drupal_core_version" value="10"/>
+
+  <!-- If you have Coder installed locally then you can reference the Drupal
+  standards with relative paths. Otherwise simply use "Drupal" and
+  "DrupalPractice. -->
+  <rule ref="../vendor/drupal/coder/coder_sniffer/Drupal">
+    <!-- Example how you would disable a rule you are not compliant with yet:
+    <exclude name="Drupal.Commenting.Deprecated"/>
+    -->
+  </rule>
+  <rule ref="../vendor/drupal/coder/coder_sniffer/DrupalPractice"/>
+
+  <!-- Example how you would disable an external rule you do not like:
+  <rule ref="PEAR.Functions.ValidDefaultValue.NotAtEnd">
+    <severity>0</severity>
+  </rule>
+  -->
+</ruleset>


### PR DESCRIPTION
This sets up a phpcs.xml file to enforce the paths (currently just `web/modules/custom` ) and the rules ( `Drupal`, `DrupalPractice`).

Testing:

I separated this PR from the one that actually contains code under that path, so it's tricksy to test. You should be able to run any of these commands and get some kind of report:

`composer phpcs path/to/file.php`
`ddev phpcs path/to.file.php`
`ddev phpcs` (will check all files under web/modules/custom)

Additionally, you can configure PHPStorm to automatically flag coding standard issues using the correct profile by following the instructions at https://www.drupaleasy.com/quicktips/ddev-integration-plugin-phpstorm-can-increase-your-drupal-development-efficiency:

1. Setting 'performance' as the the interpreter
2.  configuring the Custom path to phpcs.xml 