### PR TITLE
Replace teaser with card in Agency view

### DIFF
--- a/config/views.view.agency_content.yml
+++ b/config/views.view.agency_content.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.teaser
+    - core.entity_view_mode.node.card
     - node.type.division
     - node.type.objective
     - node.type.plan
@@ -233,7 +233,7 @@ display:
       row:
         type: 'entity:node'
         options:
-          view_mode: teaser
+          view_mode: card
       query:
         type: views_query
         options:


### PR DESCRIPTION
When testing the config updates, I was able to import and everything went fine. I went to build the site from scratch this morning with all the new code and ran into an issue on the Agency view, where it was looking for teaser but we now have it named Card. 