### PR TITLE
[PGOV-345] Add content from Mission table to agency/(sub)division con…

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -15,6 +15,7 @@ drush migrate:import media
 drush migrate:import agencies
 drush migrate:import divisions
 drush migrate:import subdivisions
+drush migrate:import missions
 drush migrate:import plans
 drush migrate:import goals
 #drush migrate:import subgoals

--- a/web/modules/custom/pgov_migrate/migrations/migrate_plus.migration.missions.yml
+++ b/web/modules/custom/pgov_migrate/migrations/migrate_plus.migration.missions.yml
@@ -1,0 +1,40 @@
+id: missions
+label: "StratML: Mission Statements"
+source:
+  plugin: airtable
+  base: 'StratML x US Performance'
+  table: 'Mission'
+  constants:
+    uid: 1
+    body_format: basic_html
+destination:
+  plugin: entity:node
+  overwrite_properties:
+    - body
+process:
+  _agency_nid:
+      plugin: migration_lookup
+      migration: agencies
+      source: Organization
+  _division_nid:
+    plugin: migration_lookup
+    migration: divisions
+    source: Division
+  _subdivision_nid:
+    plugin: migration_lookup
+    migration: subdivisions
+    source: Subdivision
+  nid:
+    -
+      plugin: null_coalesce
+      source:
+        - '@_agency_nid'
+        - '@_division_nid'
+        - '@_subdivision_nid'
+    -
+      plugin: extract
+      index:
+        - 0
+
+  body/value: Description
+  body/format: constants/body_format


### PR DESCRIPTION
This copies the Description column from the 77 rows of the Mission table into Agencies, Divisions (and subdivisions, which use the Division content type).

Testing:

* The usual `drush si --existing-site && ddev migrate` dance should work
* You can save time by running this against an existing site by using: `drush cim && drush migrate:import missions`
