### PR TITLE
Update permissions for Content Editor role

### DIFF
--- a/config/user.role.content_editor.yml
+++ b/config/user.role.content_editor.yml
@@ -16,6 +16,11 @@ dependencies:
     - node.type.page
     - node.type.plan
     - node.type.report
+    - storage.storage_type.administration
+    - storage.storage_type.indicator
+    - storage.storage_type.measurement
+    - storage.storage_type.period
+    - storage.storage_type.person
     - taxonomy.vocabulary.tags
     - taxonomy.vocabulary.topics
   module:
@@ -27,6 +32,7 @@ dependencies:
     - migrate
     - node
     - path
+    - storage
     - system
     - taxonomy
     - toolbar
@@ -44,6 +50,12 @@ permissions:
   - 'access media overview'
   - 'access taxonomy overview'
   - 'access toolbar'
+  - 'add administration storage entities'
+  - 'add indicator storage entities'
+  - 'add measurement storage entities'
+  - 'add period storage entities'
+  - 'add person storage entities'
+  - 'add storage entities'
   - 'administer media'
   - 'administer media types'
   - 'administer nodes'
@@ -67,6 +79,7 @@ permissions:
   - 'create video media'
   - 'delete agency revisions'
   - 'delete all revisions'
+  - 'delete all storage revisions'
   - 'delete all taxonomy revisions'
   - 'delete any agency content'
   - 'delete any article content'
@@ -109,6 +122,7 @@ permissions:
   - 'delete page revisions'
   - 'delete plan revisions'
   - 'delete report revisions'
+  - 'delete storage entities'
   - 'delete term revisions in tags'
   - 'delete term revisions in topics'
   - 'delete terms in tags'
@@ -138,6 +152,7 @@ permissions:
   - 'edit own remote_video media'
   - 'edit own report content'
   - 'edit own video media'
+  - 'edit storage entities'
   - 'edit terms in tags'
   - 'edit terms in topics'
   - 'link to any page'
@@ -179,7 +194,9 @@ permissions:
   - 'view own unpublished media'
   - 'view page revisions'
   - 'view plan revisions'
+  - 'view published storage entities'
   - 'view report revisions'
   - 'view term revisions in tags'
   - 'view term revisions in topics'
   - 'view the administration theme'
+  - 'view unpublished storage entities'

--- a/config/user.role.content_editor.yml
+++ b/config/user.role.content_editor.yml
@@ -31,7 +31,6 @@ dependencies:
     - media
     - migrate
     - node
-    - path
     - storage
     - system
     - taxonomy
@@ -56,8 +55,6 @@ permissions:
   - 'add period storage entities'
   - 'add person storage entities'
   - 'add storage entities'
-  - 'administer nodes'
-  - 'administer url aliases'
   - 'create agency content'
   - 'create article content'
   - 'create basic block content'
@@ -73,7 +70,6 @@ permissions:
   - 'create report content'
   - 'create terms in tags'
   - 'create terms in topics'
-  - 'create url aliases'
   - 'create video media'
   - 'delete agency revisions'
   - 'delete all revisions'

--- a/config/user.role.content_editor.yml
+++ b/config/user.role.content_editor.yml
@@ -15,6 +15,7 @@ dependencies:
     - node.type.objective
     - node.type.page
     - node.type.plan
+    - node.type.report
     - taxonomy.vocabulary.tags
     - taxonomy.vocabulary.topics
   module:
@@ -59,6 +60,7 @@ permissions:
   - 'create page content'
   - 'create plan content'
   - 'create remote_video media'
+  - 'create report content'
   - 'create terms in tags'
   - 'create terms in topics'
   - 'create url aliases'
@@ -83,6 +85,7 @@ permissions:
   - 'delete any plan content'
   - 'delete any remote_video media'
   - 'delete any remote_video media revisions'
+  - 'delete any report content'
   - 'delete any video media'
   - 'delete any video media revisions'
   - 'delete article revisions'
@@ -101,9 +104,11 @@ permissions:
   - 'delete own page content'
   - 'delete own plan content'
   - 'delete own remote_video media'
+  - 'delete own report content'
   - 'delete own video media'
   - 'delete page revisions'
   - 'delete plan revisions'
+  - 'delete report revisions'
   - 'delete term revisions in tags'
   - 'delete term revisions in topics'
   - 'delete terms in tags'
@@ -119,6 +124,7 @@ permissions:
   - 'edit any page content'
   - 'edit any plan content'
   - 'edit any remote_video media'
+  - 'edit any report content'
   - 'edit any video media'
   - 'edit own agency content'
   - 'edit own article content'
@@ -130,6 +136,7 @@ permissions:
   - 'edit own page content'
   - 'edit own plan content'
   - 'edit own remote_video media'
+  - 'edit own report content'
   - 'edit own video media'
   - 'edit terms in tags'
   - 'edit terms in topics'
@@ -148,6 +155,7 @@ permissions:
   - 'revert objective revisions'
   - 'revert page revisions'
   - 'revert plan revisions'
+  - 'revert report revisions'
   - 'revert term revisions in tags'
   - 'revert term revisions in topics'
   - 'update any media'
@@ -171,6 +179,7 @@ permissions:
   - 'view own unpublished media'
   - 'view page revisions'
   - 'view plan revisions'
+  - 'view report revisions'
   - 'view term revisions in tags'
   - 'view term revisions in topics'
   - 'view the administration theme'

--- a/config/user.role.content_editor.yml
+++ b/config/user.role.content_editor.yml
@@ -56,8 +56,6 @@ permissions:
   - 'add period storage entities'
   - 'add person storage entities'
   - 'add storage entities'
-  - 'administer media'
-  - 'administer media types'
   - 'administer nodes'
   - 'administer url aliases'
   - 'create agency content'


### PR DESCRIPTION
This PR does two things:

1. Adds permissions to view and enter all Storage types for the Content Editor role, which unblocks Jenna from not being able to see indicators and measurements on the edit forms
2. Removes all permissions that lead to the ability to access the 'Configuration Overview' tab and/or clutter up the settings sidebar on a node edit screen.

Here's what an admin form looks like now:

![image](https://github.com/user-attachments/assets/b5ed1ea2-61c4-43d0-9f68-d05f290cf339)
