### PR TITLE
Create a "dashboard" by leading with /admin/content

### DIFF
--- a/config/system.site.yml
+++ b/config/system.site.yml
@@ -6,9 +6,9 @@ name: Performance.gov
 mail: admin@example.com
 slogan: ''
 page:
-  403: ''
+  403: /user/login
   404: ''
-  front: /node
+  front: /admin/content
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: en


### PR DESCRIPTION
Jenna and I agreed that the quickest way to solve for a dashboard is to set the front page to /admin/content

Because that page needs authentication, set /user/login as the default 403 page as a quick way to show something sensible there.

Comparison images for before/after this PR are in the issue https://pgov.atlassian.net/browse/PGOV-392?focusedCommentId=10415