### PR TITLE
Feature/pgov 382 embedded table view

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "drupal/graphql": "^4.9",
         "drupal/graphql_compose": "^2.2",
         "drupal/group": "^3.2",
+        "drupal/ief_table_view_mode": "^3.0",
         "drupal/inline_entity_form": "^3.0@RC",
         "drupal/jsonapi_extras": "^3.26",
         "drupal/login_gov": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "47a89931934d66ab5fc991c0d22a58b4",
+    "content-hash": "3690db0c83d0717dac3a818ca1490f8f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2462,6 +2462,51 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/group",
                 "issues": "https://drupal.org/project/issues/group"
+            }
+        },
+        {
+            "name": "drupal/ief_table_view_mode",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/ief_table_view_mode.git",
+                "reference": "3.0.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/ief_table_view_mode-3.0.1.zip",
+                "reference": "3.0.1",
+                "shasum": "db19f8e9a5a0d345194ac13404785017cce06146"
+            },
+            "require": {
+                "drupal/core": "^10 || ^11",
+                "drupal/inline_entity_form": "^1.0 || ^2.0 || ^3.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "3.0.1",
+                    "datestamp": "1723221603",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "mnico",
+                    "homepage": "https://www.drupal.org/user/1119544"
+                }
+            ],
+            "description": "Defines a view mode to set up the columns of the table for the Inline Entity Form widget.",
+            "homepage": "https://www.drupal.org/project/ief_table_view_mode",
+            "support": {
+                "source": "https://git.drupalcode.org/project/ief_table_view_mode"
             }
         },
         {

--- a/config/core.entity_form_display.node.goal.default.yml
+++ b/config/core.entity_form_display.node.goal.default.yml
@@ -14,7 +14,7 @@ dependencies:
     - node.type.goal
   module:
     - field_group
-    - inline_entity_form
+    - ief_table_view_mode
     - path
     - text
 third_party_settings:
@@ -130,7 +130,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_objectives:
-    type: inline_entity_form_complex
+    type: inline_entity_form_complex_table_view_mode
     weight: 9
     region: content
     settings:

--- a/config/core.entity_form_display.node.objective.default.yml
+++ b/config/core.entity_form_display.node.objective.default.yml
@@ -13,7 +13,7 @@ dependencies:
     - node.type.objective
   module:
     - field_group
-    - inline_entity_form
+    - ief_table_view_mode
     - path
     - text
 third_party_settings:
@@ -115,7 +115,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_indicators:
-    type: inline_entity_form_complex
+    type: inline_entity_form_complex_table_view_mode
     weight: 12
     region: content
     settings:

--- a/config/core.entity_form_display.node.objective.inline.yml
+++ b/config/core.entity_form_display.node.objective.inline.yml
@@ -13,7 +13,7 @@ dependencies:
     - field.field.node.objective.field_objective_type
     - node.type.objective
   module:
-    - inline_entity_form
+    - ief_table_view_mode
     - text
 id: node.objective.inline
 targetEntityType: node
@@ -43,7 +43,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_indicators:
-    type: inline_entity_form_complex
+    type: inline_entity_form_complex_table_view_mode
     weight: 5
     region: content
     settings:

--- a/config/core.entity_form_display.node.plan.default.yml
+++ b/config/core.entity_form_display.node.plan.default.yml
@@ -17,7 +17,7 @@ dependencies:
   module:
     - datetime
     - field_group
-    - inline_entity_form
+    - ief_table_view_mode
     - link
     - media_library
     - path
@@ -154,7 +154,7 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_goals:
-    type: inline_entity_form_complex
+    type: inline_entity_form_complex_table_view_mode
     weight: 2
     region: content
     settings:

--- a/config/core.entity_form_display.storage.indicator.default.yml
+++ b/config/core.entity_form_display.storage.indicator.default.yml
@@ -17,7 +17,7 @@ dependencies:
     - storage.storage_type.indicator
   module:
     - field_group
-    - inline_entity_form
+    - ief_table_view_mode
     - text
 third_party_settings:
   field_group:
@@ -88,7 +88,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_measurements:
-    type: inline_entity_form_complex
+    type: inline_entity_form_complex_table_view_mode
     weight: 8
     region: content
     settings:

--- a/config/core.entity_form_display.storage.indicator.inline.yml
+++ b/config/core.entity_form_display.storage.indicator.inline.yml
@@ -17,7 +17,7 @@ dependencies:
     - storage.storage_type.indicator
   module:
     - field_group
-    - inline_entity_form
+    - ief_table_view_mode
     - text
 third_party_settings:
   field_group:
@@ -88,14 +88,14 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_measurements:
-    type: inline_entity_form_complex
+    type: inline_entity_form_complex_table_view_mode
     weight: 7
     region: content
     settings:
       form_mode: inline
-      override_labels: false
-      label_singular: ''
-      label_plural: ''
+      override_labels: true
+      label_singular: measurement
+      label_plural: measurements
       allow_new: true
       allow_existing: false
       match_operator: CONTAINS

--- a/config/core.entity_view_display.node.goal.ief_table.yml
+++ b/config/core.entity_view_display.node.goal.ief_table.yml
@@ -1,0 +1,55 @@
+uuid: 4f088629-3d0c-4145-9eb1-7524e3902a2c
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.ief_table
+    - field.field.node.goal.body
+    - field.field.node.goal.field_goal_type
+    - field.field.node.goal.field_id
+    - field.field.node.goal.field_objectives
+    - field.field.node.goal.field_period
+    - field.field.node.goal.field_plan
+    - field.field.node.goal.field_topics
+    - node.type.goal
+  module:
+    - options
+    - text
+    - user
+id: node.goal.ief_table
+targetEntityType: node
+bundle: goal
+mode: ief_table
+content:
+  body:
+    type: text_summary_or_trimmed
+    label: hidden
+    settings:
+      trim_length: 100
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_goal_type:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_period:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_id: true
+  field_objectives: true
+  field_plan: true
+  field_topics: true
+  label: true
+  links: true
+  search_api_excerpt: true
+  status: true

--- a/config/core.entity_view_display.node.objective.ief_table.yml
+++ b/config/core.entity_view_display.node.objective.ief_table.yml
@@ -1,0 +1,42 @@
+uuid: 5f8ba2fe-7212-4cf6-ade9-f650dc2a5109
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.ief_table
+    - field.field.node.objective.body
+    - field.field.node.objective.field_agency
+    - field.field.node.objective.field_division
+    - field.field.node.objective.field_goal
+    - field.field.node.objective.field_indicators
+    - field.field.node.objective.field_objective_type
+    - node.type.objective
+  module:
+    - options
+    - user
+id: node.objective.ief_table
+targetEntityType: node
+bundle: objective
+mode: ief_table
+content:
+  field_objective_type:
+    type: list_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  label:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  body: true
+  field_agency: true
+  field_division: true
+  field_goal: true
+  field_indicators: true
+  links: true
+  search_api_excerpt: true
+  status: true

--- a/config/core.entity_view_display.storage.indicator.ief_table.yml
+++ b/config/core.entity_view_display.storage.indicator.ief_table.yml
@@ -1,0 +1,52 @@
+uuid: b01c8b85-27dc-43d1-aaf3-0ccc2fef43de
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.storage.ief_table
+    - field.field.storage.indicator.field_description
+    - field.field.storage.indicator.field_dimension
+    - field.field.storage.indicator.field_divisions
+    - field.field.storage.indicator.field_id
+    - field.field.storage.indicator.field_keyness
+    - field.field.storage.indicator.field_measurements
+    - field.field.storage.indicator.field_notes
+    - field.field.storage.indicator.field_objective
+    - field.field.storage.indicator.field_plan
+    - field.field.storage.indicator.field_target
+    - storage.storage_type.indicator
+  module:
+    - text
+id: storage.indicator.ief_table
+targetEntityType: storage
+bundle: indicator
+mode: ief_table
+content:
+  field_description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_id:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_dimension: true
+  field_divisions: true
+  field_keyness: true
+  field_measurements: true
+  field_notes: true
+  field_objective: true
+  field_plan: true
+  field_target: true
+  label: true
+  name: true
+  search_api_excerpt: true
+  user_id: true

--- a/config/core.entity_view_display.storage.measurement.ief_table.yml
+++ b/config/core.entity_view_display.storage.measurement.ief_table.yml
@@ -1,0 +1,52 @@
+uuid: f0afb107-58ba-422c-9f36-6ca9112f2710
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.storage.ief_table
+    - field.field.storage.measurement.field_indicator
+    - field.field.storage.measurement.field_period
+    - field.field.storage.measurement.field_target_value
+    - field.field.storage.measurement.field_value
+    - storage.storage_type.measurement
+id: storage.measurement.ief_table
+targetEntityType: storage
+bundle: measurement
+mode: ief_table
+content:
+  field_period:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_target_value:
+    type: number_decimal
+    label: hidden
+    settings:
+      thousand_separator: ''
+      decimal_separator: .
+      scale: 2
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_value:
+    type: number_decimal
+    label: hidden
+    settings:
+      thousand_separator: ''
+      decimal_separator: .
+      scale: 2
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  field_indicator: true
+  label: true
+  name: true
+  search_api_excerpt: true
+  user_id: true

--- a/config/core.entity_view_mode.node.ief_table.yml
+++ b/config/core.entity_view_mode.node.ief_table.yml
@@ -1,0 +1,11 @@
+uuid: 6af89212-2057-4a74-8a07-cbf6ea7a8a12
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.ief_table
+label: 'Inline Entity Form Table'
+description: ''
+targetEntityType: node
+cache: true

--- a/config/core.entity_view_mode.storage.ief_table.yml
+++ b/config/core.entity_view_mode.storage.ief_table.yml
@@ -1,0 +1,11 @@
+uuid: c31ea93a-2484-4046-b523-97e3d6b258ed
+langcode: en
+status: true
+dependencies:
+  module:
+    - storage
+id: storage.ief_table
+label: 'Inline Entity Form Table'
+description: ''
+targetEntityType: storage
+cache: true

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -45,6 +45,7 @@ module:
   graphql_compose_views: 0
   graphql_examples: 0
   help: 0
+  ief_table_view_mode: 0
   image: 0
   inline_entity_form: 0
   jsonapi: 0


### PR DESCRIPTION
This PR creates table view modes for all inline entity forms, which are configured to show pertinent details about the embedded item instead of just its title and published status.

Full details/output are here: https://pgov.atlassian.net/browse/PGOV-382?focusedCommentId=10418

The most useful example is on Measurements:

BEFORE: ![image](https://github.com/user-attachments/assets/0f34ae52-b0c1-47ce-b696-f343d14d522a)

AFTER: ![image](https://github.com/user-attachments/assets/39fbdaca-4d84-4f1c-9a40-77da07a7e7f9)

**Testing:**

Visit any embedded form ( Goal tab on Plans, Objectives tab on Goals, Performance Indicators on Objectives) and view the summary of child items.