### PR TITLE
PGOV-381: Add Tagify module for taxonomy fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "drupal/search_api": "^1.35",
         "drupal/storage": "^1.3",
         "drupal/svg_image": "^3.2",
+        "drupal/tagify": "^1.2",
         "drupal/title_length": "^2.1",
         "drupal/type_tray": "^1.3",
         "drupal/workflow": "^1.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3690db0c83d0717dac3a818ca1490f8f",
+    "content-hash": "9321eb25ac1b7e8ff16ab16b52dca792",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3457,6 +3457,57 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/svg_image",
                 "issues": "https://www.drupal.org/project/issues/svg_image"
+            }
+        },
+        {
+            "name": "drupal/tagify",
+            "version": "1.2.26",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/tagify.git",
+                "reference": "1.2.26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/tagify-1.2.26.zip",
+                "reference": "1.2.26",
+                "shasum": "0c044c6fa1c65b39a0c446351f6f0b6247f4fc07"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9 || ^10 || ^11"
+            },
+            "require-dev": {
+                "drupal/better_exposed_filters": "^7.0",
+                "drupal/facets": "^2.0",
+                "drupal/iconify_icons": "*",
+                "drupal/search_api": "^1.31"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.2.26",
+                    "datestamp": "1734023285",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "David Galeano",
+                    "homepage": "https://www.drupal.org/u/gxleano"
+                }
+            ],
+            "description": "Integration with the Tagify JavaScript library.",
+            "homepage": "https://drupal.org/project/tagify",
+            "support": {
+                "source": "https://git.drupalcode.org/project/tagify",
+                "issues": "https://www.drupal.org/project/issues/tagify"
             }
         },
         {

--- a/config/core.entity_form_display.node.article.default.yml
+++ b/config/core.entity_form_display.node.article.default.yml
@@ -10,6 +10,7 @@ dependencies:
   module:
     - media_library
     - path
+    - tagify
     - text
 _core:
   default_config_hash: ewbd6G2uX456-bgwseM2Q-KQG3RkASoyHmTh-XR3oLU
@@ -42,14 +43,17 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_tags:
-    type: entity_reference_autocomplete_tags
+    type: tagify_entity_reference_autocomplete_widget
     weight: 3
     region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
-      size: 60
       placeholder: ''
+      suggestions_dropdown: 1
+      show_entity_id: 0
+      show_info_label: 0
+      info_label: ''
     third_party_settings: {  }
   path:
     type: path

--- a/config/core.entity_form_display.node.goal.default.yml
+++ b/config/core.entity_form_display.node.goal.default.yml
@@ -16,6 +16,7 @@ dependencies:
     - field_group
     - ief_table_view_mode
     - path
+    - tagify
     - text
 third_party_settings:
   field_group:
@@ -160,14 +161,17 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_topics:
-    type: entity_reference_autocomplete_tags
+    type: tagify_entity_reference_autocomplete_widget
     weight: 8
     region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
-      size: 60
       placeholder: ''
+      suggestions_dropdown: 1
+      show_entity_id: 0
+      show_info_label: 0
+      info_label: ''
     third_party_settings: {  }
   path:
     type: path

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -82,6 +82,7 @@ module:
   subrequests: 0
   svg_image: 0
   system: 0
+  tagify: 0
   taxonomy: 0
   text: 0
   title_length: 0


### PR DESCRIPTION
This adds the tagify module and updates the two taxonomy fields on the site to use it. 

To test:

1. pull code
2. install the new module via composer
3. import config to turn on the module and add it to the content forms
4. Visit the goal page and test out the topics field
5. Articles also got an update but they aren't being used