### PR TITLE
Update InPage Nav links for Agency pages

### DIFF
--- a/config/graphql_compose.settings.yml
+++ b/config/graphql_compose.settings.yml
@@ -137,6 +137,7 @@ field_config:
         enabled: true
       field_id:
         enabled: true
+        name_sdl: fieldId
       field_objectives:
         enabled: true
       field_period:

--- a/src/frontend/components/field--goals.tsx
+++ b/src/frontend/components/field--goals.tsx
@@ -3,12 +3,13 @@ import Link from 'next/link'
 interface FieldGoalsProps {
   goals: any;
   title: string;
+  titleId: string;
 }
 
-export function FieldGoals({goals, title, ...props}:FieldGoalsProps) {
+export function FieldGoals({goals, title, titleId, ...props}:FieldGoalsProps) {
   return (
     <>
-      <h3>{title}</h3>
+      <h3 id={titleId}>{title}</h3>
       <ul className="">
         {goals.map((goal) => (
           <li className="" key={goal.id}>

--- a/src/frontend/components/node--agency.tsx
+++ b/src/frontend/components/node--agency.tsx
@@ -12,25 +12,25 @@ export function NodeAgency({ node, planData, ...props }: NodeAgencyProps) {
   const breadcrumbLinks = [
     {label: "Agencies", href: "/agencies"},
   ];
-  console.log(planData)
   function buildInPageLinks() {
     let links = [
       {href: "#mission", label: `Mission`, primary: true}
     ];
     if (planData && planData.length > 0) {
       planData.forEach((plan) => {
-        links.push({href: `#${plan.id}`, label: plan.title, primary: true})
+        links.push({href: `#${plan.id}`, label: plan.title, primary: true});
+        if(plan.goals?.filter((goal) => goal.goalType === "strategic").length > 0) {
+          links.push({href: `#${plan.id}-strategic`, label: "Strategic goals", primary: false});
+        }
+        if(plan.goals?.filter((goal) => goal.goalType === "apg").length > 0) {
+          links.push({href: `#${plan.id}-apg`, label: "Agency priority goals", primary: false});
+        }
+        if(plan.link) {
+          links.push({href: `#${plan.id}-documents`, label: "Related documents", primary: false});
+        }
       })
     }
-    // if (storageData.objectives) {
-    //   links.push({href: "#objectives", label: `Objectives`, primary: true});
-    //   storageData.objectives.forEach((objective) => {
-    //     links.push({href: `#${objective.id}`, label: objective.title, primary: false });
-    //   })
-
-    // }
-
-    links.push({href: "#related-resources", label: `Related Resources`, primary: true})
+    links.push({href: "#related-resources", label: `Related Resources`, primary: true});
     return links;
   }
 

--- a/src/frontend/components/node--agency.tsx
+++ b/src/frontend/components/node--agency.tsx
@@ -12,6 +12,27 @@ export function NodeAgency({ node, planData, ...props }: NodeAgencyProps) {
   const breadcrumbLinks = [
     {label: "Agencies", href: "/agencies"},
   ];
+  console.log(planData)
+  function buildInPageLinks() {
+    let links = [
+      {href: "#mission", label: `Mission`, primary: true}
+    ];
+    if (planData && planData.length > 0) {
+      planData.forEach((plan) => {
+        links.push({href: `#${plan.id}`, label: plan.title, primary: true})
+      })
+    }
+    // if (storageData.objectives) {
+    //   links.push({href: "#objectives", label: `Objectives`, primary: true});
+    //   storageData.objectives.forEach((objective) => {
+    //     links.push({href: `#${objective.id}`, label: objective.title, primary: false });
+    //   })
+
+    // }
+
+    links.push({href: "#related-resources", label: `Related Resources`, primary: true})
+    return links;
+  }
 
   return (
     <>
@@ -20,12 +41,7 @@ export function NodeAgency({ node, planData, ...props }: NodeAgencyProps) {
         <div className="desktop:grid-col-4">
           <USAInPageNav
             logo={node.field_logo ? node.field_logo : null}
-            links={[
-              {href: "#mission", label: `Mission`},
-              {href: "#component-preview", label: `Admin`},
-              {href: "#component-code", label: `Fiscal period`},
-              {href: "#related-resources", label: `Related Resources`},
-            ]}
+            links={buildInPageLinks()}
           />
         </div>
         <div className="desktop:grid-col-8">

--- a/src/frontend/components/node--plan.tsx
+++ b/src/frontend/components/node--plan.tsx
@@ -13,16 +13,16 @@ export function NodePlan({plan, ...props}: NodeGoalProps) {
     <>
       <h2 id={plan.id}>{plan.title}</h2>
       {strategic?.length > 0 && (
-        <FieldGoals goals={strategic} title={"Strategic goals"} />
+        <FieldGoals goals={strategic} titleId={`${plan.id}-strategic`} title={"Strategic goals"} />
       )}
 
       {apgs?.length > 0 && (
-        <FieldGoals goals={apgs} title={"Agency priority goals"} />
+        <FieldGoals goals={apgs} titleId={`${plan.id}-apg`} title={"Agency priority goals"} />
       )}
 
       {plan?.link?.url && (
         <>
-          <h3>Related documents</h3>
+          <h3 id={`${plan.id}-documents`}>Related documents</h3>
           <ul>
             <li><Link href={plan?.link?.url}>{plan.title}</Link></li>
           </ul>

--- a/src/frontend/components/node--plan.tsx
+++ b/src/frontend/components/node--plan.tsx
@@ -11,7 +11,7 @@ export function NodePlan({plan, ...props}: NodeGoalProps) {
   const strategic = plan?.goals?.filter((goal) => goal.goalType === "strategic");
   return (
     <>
-      <h2>{plan.title}</h2>
+      <h2 id={plan.id}>{plan.title}</h2>
       {strategic?.length > 0 && (
         <FieldGoals goals={strategic} title={"Strategic goals"} />
       )}

--- a/src/frontend/components/view--goal-search.tsx
+++ b/src/frontend/components/view--goal-search.tsx
@@ -153,8 +153,7 @@ export default function GoalsSearchView({ filters, goals, total, description }: 
         <ul className="usa-card-group">
           {filteredGoals.map((goal) => (
             <li
-              // Not all goals have an ID, so path is the next most unique.
-              key={goal.path}
+              key={goal.id}
               className="usa-card tablet-lg:grid-col-6 desktop:grid-col-4"
             >
               <NodeGoalCard goal={goal} />

--- a/src/frontend/lib/types.ts
+++ b/src/frontend/lib/types.ts
@@ -1,5 +1,6 @@
 export interface NodeGoalProps {
   title: string,
+  id: string,
   body: {
     value: string
   },

--- a/src/frontend/pages/api/node-queries.ts
+++ b/src/frontend/pages/api/node-queries.ts
@@ -70,6 +70,7 @@ export const strategicPlanQueries = {
         goals {
           ... on NodeGoal {
             id
+            fieldId
             title
             goalType
             path


### PR DESCRIPTION
This PR adds a function and some ids to h2/h3s on the Agency page to build the in page navigation. 
It also includes an update to the Goals graphql compose setting, changing field_id to be `fieldId` instead of `id` which was overwriting the uuid for each node. This was causing a bunch of warnings when looping through goals because many of the keys were null and not unique. With this change I was able to update the homepage goal keys to use the uuid and not path names. 