### PR TITLE
PGOV-414: Disable preview button on content types

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2126,17 +2126,17 @@
         },
         {
             "name": "drupal/gin",
-            "version": "3.0.0-rc14",
+            "version": "3.0.0-rc15",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/gin.git",
-                "reference": "8.x-3.0-rc14"
+                "reference": "8.x-3.0-rc15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/gin-8.x-3.0-rc14.zip",
-                "reference": "8.x-3.0-rc14",
-                "shasum": "8ca8735f5a1d7ef25ee446358cd704a3feb1cae7"
+                "url": "https://ftp.drupal.org/files/projects/gin-8.x-3.0-rc15.zip",
+                "reference": "8.x-3.0-rc15",
+                "shasum": "245f8444a8534cff04eac57c0b07e4f44481cabc"
             },
             "require": {
                 "drupal/core": "^9 || ^10 || ^11",
@@ -2145,8 +2145,8 @@
             "type": "drupal-theme",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.0-rc14",
-                    "datestamp": "1731015952",
+                    "version": "8.x-3.0-rc15",
+                    "datestamp": "1733734246",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."

--- a/config/node.type.agency.yml
+++ b/config/node.type.agency.yml
@@ -21,5 +21,5 @@ type: agency
 description: 'An agency responsible for goals and priorities.'
 help: null
 new_revision: true
-preview_mode: 1
+preview_mode: 0
 display_submitted: false

--- a/config/node.type.article.yml
+++ b/config/node.type.article.yml
@@ -3,10 +3,20 @@ langcode: en
 status: true
 dependencies:
   module:
+    - menu_ui
     - type_tray
 third_party_settings:
   type_tray:
+    type_category: _none
+    type_thumbnail: ''
+    type_icon: ''
+    type_description: ''
     existing_nodes_link_text: 'View existing <em class="placeholder">Article</em> content'
+    type_weight: 0
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
 _core:
   default_config_hash: Fe3N1uqaAyyKJbVkqT-btXy3t98puW8GCRD822xjl10
 name: Article
@@ -14,5 +24,5 @@ type: article
 description: 'Use <em>articles</em> for time-sensitive content like news, press releases or blog posts.'
 help: null
 new_revision: true
-preview_mode: 1
+preview_mode: 0
 display_submitted: true

--- a/config/node.type.division.yml
+++ b/config/node.type.division.yml
@@ -21,5 +21,5 @@ type: division
 description: 'An agency division'
 help: null
 new_revision: true
-preview_mode: 1
+preview_mode: 0
 display_submitted: false

--- a/config/node.type.goal.yml
+++ b/config/node.type.goal.yml
@@ -21,5 +21,5 @@ type: goal
 description: 'An administration goal'
 help: null
 new_revision: true
-preview_mode: 1
+preview_mode: 0
 display_submitted: false

--- a/config/node.type.objective.yml
+++ b/config/node.type.objective.yml
@@ -21,5 +21,5 @@ type: objective
 description: 'Objectives break down goals and sub-goals into specific, actionable objectives whose progress can be measured.'
 help: null
 new_revision: true
-preview_mode: 1
+preview_mode: 0
 display_submitted: false

--- a/config/node.type.page.yml
+++ b/config/node.type.page.yml
@@ -24,5 +24,5 @@ type: page
 description: "Use <em>basic pages</em> for your static content, such as an 'About us' page."
 help: null
 new_revision: true
-preview_mode: 1
+preview_mode: 0
 display_submitted: false

--- a/config/node.type.plan.yml
+++ b/config/node.type.plan.yml
@@ -21,5 +21,5 @@ type: plan
 description: 'Strategies represented by agency and White House strategic plans.'
 help: null
 new_revision: true
-preview_mode: 1
+preview_mode: 0
 display_submitted: false

--- a/config/node.type.report.yml
+++ b/config/node.type.report.yml
@@ -21,5 +21,5 @@ type: report
 description: 'Identifies inputs and processes required to accomplish objectives and establishing metrics by which progress will be assessed within a single budgetary planning and resource allocation cycle.'
 help: null
 new_revision: true
-preview_mode: 1
+preview_mode: 0
 display_submitted: false


### PR DESCRIPTION
I'm 100% sure why node--article updated with more than the rest when I turned off its preview button. 

It looks like there was an issue fixed in the newest release of Gin (rc15) that hides the preview button once it is disabled on a content type. https://www.drupal.org/project/gin/issues/3492067

To test:

1. Pull code
2. Run ddev composer install to get newest gin theme
3. Try to add/edit any of the content types and make sure there is no preview button on the edit page. 