### PR TITLE
PGOV-378: Show agency and divisions by acronym instead of full name

### DIFF
--- a/config/field.field.node.objective.field_agency.yml
+++ b/config/field.field.node.objective.field_agency.yml
@@ -20,6 +20,6 @@ settings:
   handler_settings:
     view:
       view_name: agencies
-      display_name: entity_reference_1
+      display_name: agency_acronym_entity_reference
       arguments: {  }
 field_type: entity_reference

--- a/config/field.field.node.objective.field_agency.yml
+++ b/config/field.field.node.objective.field_agency.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_agency
-    - node.type.agency
     - node.type.objective
 id: node.objective.field_agency
 field_name: field_agency
@@ -17,13 +16,10 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: 'default:node'
+  handler: views
   handler_settings:
-    target_bundles:
-      agency: agency
-    sort:
-      field: title
-      direction: ASC
-    auto_create: false
-    auto_create_bundle: ''
+    view:
+      view_name: agencies
+      display_name: entity_reference_1
+      arguments: {  }
 field_type: entity_reference

--- a/config/field.field.node.objective.field_division.yml
+++ b/config/field.field.node.objective.field_division.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_division
-    - node.type.division
     - node.type.objective
 id: node.objective.field_division
 field_name: field_division
@@ -17,13 +16,10 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: 'default:node'
+  handler: views
   handler_settings:
-    target_bundles:
-      division: division
-    sort:
-      field: title
-      direction: ASC
-    auto_create: false
-    auto_create_bundle: ''
+    view:
+      view_name: divisions
+      display_name: entity_reference_1
+      arguments: {  }
 field_type: entity_reference

--- a/config/field.field.node.objective.field_division.yml
+++ b/config/field.field.node.objective.field_division.yml
@@ -20,6 +20,6 @@ settings:
   handler_settings:
     view:
       view_name: divisions
-      display_name: entity_reference_1
+      display_name: divisions_acronym_entity_reference
       arguments: {  }
 field_type: entity_reference

--- a/config/field.field.node.plan.field_agency.yml
+++ b/config/field.field.node.plan.field_agency.yml
@@ -20,6 +20,6 @@ settings:
   handler_settings:
     view:
       view_name: agencies
-      display_name: entity_reference_1
+      display_name: agency_acronym_entity_reference
       arguments: {  }
 field_type: entity_reference

--- a/config/field.field.node.plan.field_agency.yml
+++ b/config/field.field.node.plan.field_agency.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_agency
-    - node.type.agency
     - node.type.plan
 id: node.plan.field_agency
 field_name: field_agency
@@ -17,13 +16,10 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: 'default:node'
+  handler: views
   handler_settings:
-    target_bundles:
-      agency: agency
-    sort:
-      field: title
-      direction: ASC
-    auto_create: false
-    auto_create_bundle: ''
+    view:
+      view_name: agencies
+      display_name: entity_reference_1
+      arguments: {  }
 field_type: entity_reference

--- a/config/field.field.node.plan.field_division.yml
+++ b/config/field.field.node.plan.field_division.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_division
-    - node.type.division
     - node.type.plan
 id: node.plan.field_division
 field_name: field_division
@@ -17,13 +16,10 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: 'default:node'
+  handler: views
   handler_settings:
-    target_bundles:
-      division: division
-    sort:
-      field: title
-      direction: ASC
-    auto_create: false
-    auto_create_bundle: ''
+    view:
+      view_name: divisions
+      display_name: entity_reference_1
+      arguments: {  }
 field_type: entity_reference

--- a/config/field.field.node.plan.field_division.yml
+++ b/config/field.field.node.plan.field_division.yml
@@ -20,6 +20,6 @@ settings:
   handler_settings:
     view:
       view_name: divisions
-      display_name: entity_reference_1
+      display_name: divisions_acronym_entity_reference
       arguments: {  }
 field_type: entity_reference

--- a/config/views.view.agencies.yml
+++ b/config/views.view.agencies.yml
@@ -181,8 +181,8 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
-  entity_reference_1:
-    id: entity_reference_1
+  agency_acronym_entity_reference:
+    id: agency_acronym_entity_reference
     display_title: 'Entity Reference by Acronym'
     display_plugin: entity_reference
     position: 2

--- a/config/views.view.agencies.yml
+++ b/config/views.view.agencies.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.card
+    - field.storage.node.field_acronym
     - node.type.agency
   module:
     - node
@@ -180,6 +181,98 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
+  entity_reference_1:
+    id: entity_reference_1
+    display_title: 'Entity Reference by Acronym'
+    display_plugin: entity_reference
+    position: 2
+    display_options:
+      fields:
+        field_acronym:
+          id: field_acronym
+          table: node__field_acronym
+          field: field_acronym
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: none
+        options:
+          offset: 0
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            field_acronym: field_acronym
+      defaults:
+        fields: false
+      display_description: ''
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_acronym'
   page_1:
     id: page_1
     display_title: Page

--- a/config/views.view.divisions.yml
+++ b/config/views.view.divisions.yml
@@ -182,8 +182,8 @@ display:
         - user.permissions
       tags:
         - 'config:field.storage.node.field_acronym'
-  entity_reference_1:
-    id: entity_reference_1
+  divisions_acronym_entity_reference:
+    id: divisions_acronym_entity_reference
     display_title: 'Entity Reference by Acronym'
     display_plugin: entity_reference
     position: 1

--- a/config/views.view.divisions.yml
+++ b/config/views.view.divisions.yml
@@ -1,0 +1,213 @@
+uuid: e24fd8c7-31b5-40c1-8c83-0f0e48490f73
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_acronym
+    - node.type.division
+  module:
+    - node
+    - user
+id: divisions
+label: Divisions
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      fields:
+        field_acronym:
+          id: field_acronym
+          table: node__field_acronym
+          field: field_acronym
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: mini
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            division: division
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_acronym'
+  entity_reference_1:
+    id: entity_reference_1
+    display_title: 'Entity Reference by Acronym'
+    display_plugin: entity_reference
+    position: 1
+    display_options:
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            field_acronym: field_acronym
+      row:
+        type: entity_reference
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: '-'
+          hide_empty: false
+      display_description: ''
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_acronym'


### PR DESCRIPTION
This PR updates the field_agency and field_divisions to use an entity view instead of the default entity by title field. 

To test:

1. pull code
2. run config import
3. On goal, plan, and objective content nodes the agency and division fields should now show acronyms and not the full agency title