### PR TITLE
Update measurements ordinality and attempt to sort by date

### DIFF
--- a/config/cer.corresponding_reference.goal_objectives.yml
+++ b/config/cer.corresponding_reference.goal_objectives.yml
@@ -5,8 +5,8 @@ dependencies: {  }
 id: goal_objectives
 label: 'Objectives for a goal'
 enabled: true
-first_field: field_goal
-second_field: field_objectives
+first_field: field_objectives
+second_field: field_goal
 add_direction: append
 bundles:
   node:

--- a/config/cer.corresponding_reference.indicator_measurements.yml
+++ b/config/cer.corresponding_reference.indicator_measurements.yml
@@ -5,8 +5,8 @@ dependencies: {  }
 id: indicator_measurements
 label: 'Measurements for a performance indicator'
 enabled: true
-first_field: field_indicator
-second_field: field_measurements
+first_field: field_measurements
+second_field: field_indicator
 add_direction: append
 bundles:
   storage:

--- a/config/cer.corresponding_reference.objective_indicators.yml
+++ b/config/cer.corresponding_reference.objective_indicators.yml
@@ -5,8 +5,8 @@ dependencies: {  }
 id: objective_indicators
 label: 'Performance indicators for an objective'
 enabled: true
-first_field: field_objective
-second_field: field_indicators
+first_field: field_indicators
+second_field: field_objective
 add_direction: append
 bundles:
   node:

--- a/config/cer.corresponding_reference.plan_goals.yml
+++ b/config/cer.corresponding_reference.plan_goals.yml
@@ -5,8 +5,8 @@ dependencies: {  }
 id: plan_goals
 label: 'Goals in a plan'
 enabled: true
-first_field: field_plan
-second_field: field_goals
+first_field: field_goals
+second_field: field_plan
 add_direction: append
 bundles:
   node:

--- a/config/field.storage.storage.field_measurements.yml
+++ b/config/field.storage.storage.field_measurements.yml
@@ -12,7 +12,7 @@ settings:
   target_type: storage
 module: core
 locked: false
-cardinality: 4
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/migrate_plus.migration.measurements.yml
+++ b/config/migrate_plus.migration.measurements.yml
@@ -13,6 +13,8 @@ source:
   plugin: airtable
   base: 'StratML x US Performance'
   table: MeasurementInstance
+  sort: EndDate
+  direction: asc
   constants:
     uid: 1
     body_format: basic_html

--- a/config/migrate_plus.migration.plan_files.yml
+++ b/config/migrate_plus.migration.plan_files.yml
@@ -19,7 +19,7 @@ source:
     file_destination: 'public://documents/'
 process:
   uid: constants/uid
-  source_full_path:
+  _source_full_path:
     plugin: extract
     source: File
     index:
@@ -40,19 +40,19 @@ process:
   _subfolder:
     plugin: format_date
     from_format: Y-m-d
-    to_format: Y/m/
+    to_format: /Y/m/
     source: StartDate
-  destination_full_path:
+  _destination_full_path:
     plugin: concat
     source:
       - constants/file_destination
       - '@_subfolder'
-      - filename
+      - '@filename'
   uri:
     plugin: file_copy
     source:
-      - '@source_full_path'
-      - '@destination_full_path'
+      - '@_source_full_path'
+      - '@_destination_full_path'
 destination:
   plugin: 'entity:file'
 migration_dependencies: null

--- a/config/migrate_plus.migration.report_files.yml
+++ b/config/migrate_plus.migration.report_files.yml
@@ -41,13 +41,13 @@ process:
     plugin: format_date
     from_format: Y-m-d
     to_format: Y/m/
-    source: StartDate
+    source: EndDate
   destination_full_path:
     plugin: concat
     source:
       - constants/file_destination
       - '@_subfolder'
-      - filename
+      - '@filename'
   uri:
     plugin: file_copy
     source:

--- a/web/modules/custom/pgov_migrate/migrations/migrate_plus.migration.goals.yml
+++ b/web/modules/custom/pgov_migrate/migrations/migrate_plus.migration.goals.yml
@@ -14,6 +14,8 @@ source:
     body_format: basic_html
     file_destination: 'public://images/'
     delimiter: '-'
+    sort: 'EndDate'
+    direction: 'asc'
 destination:
   plugin: entity:node
   default_bundle: goal

--- a/web/modules/custom/pgov_migrate/migrations/migrate_plus.migration.measurements.yml
+++ b/web/modules/custom/pgov_migrate/migrations/migrate_plus.migration.measurements.yml
@@ -4,6 +4,8 @@ source:
   plugin: airtable
   base: 'StratML x US Performance'
   table: 'MeasurementInstance'
+  sort: 'EndDate'
+  direction: 'asc'
   constants:
     uid: 1
     body_format: basic_html

--- a/web/modules/custom/pgov_migrate/migrations/migrate_plus.migration.reports.yml
+++ b/web/modules/custom/pgov_migrate/migrations/migrate_plus.migration.reports.yml
@@ -7,6 +7,8 @@ source:
   plugin: airtable
   base: 'StratML x US Performance'
   table: 'PerformancePlanOrReport'
+  sort: 'EndDate'
+  direction: 'asc'
   constants:
     uid: 1
     body_format: basic_html

--- a/web/modules/custom/pgov_migrate/src/Plugin/migrate/source/Airtable.php
+++ b/web/modules/custom/pgov_migrate/src/Plugin/migrate/source/Airtable.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\pgov_migrate\Plugin\migrate\source;
 
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate_plus\Plugin\migrate\source\Url;
 
@@ -22,6 +23,8 @@ use Drupal\migrate_plus\Plugin\migrate\source\Url;
  * )
  */
 class Airtable extends Url {
+
+  use StringTranslationTrait;
 
   /**
    * Airtable's API URL; is the base of all requests.
@@ -177,6 +180,14 @@ class Airtable extends Url {
     }
     if (isset($configuration['view'])) {
       $url .= '&view=' . urlencode($configuration['view']);
+    }
+    if (isset($configuration['sort'])) {
+      $sort = $this->t('sort[0][field]=@sort', ['@sort' => $configuration['sort']]);
+      $url .= urlencode($sort);
+      if (isset($configuration['direction'])) {
+        $sort = $this->t('sort[0][direction]=@direction', ['@direction' => $configuration['direction']]);
+        $url .= urlencode($sort);
+      }
     }
     $configuration['urls'] = [$url];
 


### PR DESCRIPTION
The main fix in this branch is to remove the limit on measurements that can be applied to a performance indicator. This was probably causing some data loss, and was definitely making it so you couldn't add new measurements in most cases.

*requires a migration*

Also attempts to sort measurements by date on the performance indicator's field_measurements. This doesn't seem to be working the way I want, but it's not _worse_, so we can iterate on that post-mvp.