### PR TITLE
Adds missing backslash in goal urls

### DIFF
--- a/config/pathauto.pattern.goal.yml
+++ b/config/pathauto.pattern.goal.yml
@@ -7,12 +7,12 @@ dependencies:
 id: goal
 label: Goal
 type: 'canonical_entities:node'
-pattern: '/agencies[node:field_plan:entity:field_agency:entity:field_acronym]/[node:title]'
+pattern: '/agencies/[node:field_plan:entity:field_agency:entity:field_acronym]/[node:title]'
 selection_criteria:
-  9702f5f9-3d17-4be3-baea-5c2cf4f01fe3:
+  f575e849-76c7-4dc5-b5c9-d7f550130833:
     id: 'entity_bundle:node'
     negate: false
-    uuid: 9702f5f9-3d17-4be3-baea-5c2cf4f01fe3
+    uuid: f575e849-76c7-4dc5-b5c9-d7f550130833
     context_mapping:
       node: node
     bundles:


### PR DESCRIPTION
The current path auto setup is missing a backslash between agencies and the agency acronym. This config update adds the slash back into the url. After importing the config, you will need to go to /admin/config/search/path/update_bulk and update the url paths to regenerate the correct paths. I am not sure if this will require a new build on the frontend or of the slug template will pick it up on the next request. 