### PR TITLE
Initial nextjs api endpoint commit

### DIFF
--- a/config/search_api.index.goals.yml
+++ b/config/search_api.index.goals.yml
@@ -21,7 +21,6 @@ field_settings:
       type: union
       fields:
         - 'entity:node/body'
-        - 'entity:node/field_topics'
         - 'entity:node/title'
   name:
     label: 'Topics » Taxonomy term » Name'
@@ -47,8 +46,26 @@ processor_settings:
   aggregated_field: {  }
   custom_value: {  }
   entity_type: {  }
+  ignorecase:
+    weights:
+      preprocess_index: -20
+      preprocess_query: -20
+    all_fields: false
+    fields:
+      - aggregated_field
   language_with_fallback: {  }
   rendered_item: {  }
+  tokenizer:
+    weights:
+      preprocess_index: -6
+      preprocess_query: -6
+    all_fields: false
+    fields:
+      - aggregated_field
+    spaces: ''
+    ignored: ._-
+    overlap_cjk: 1
+    minimum_word_size: '3'
 tracker_settings:
   default:
     indexing_order: fifo

--- a/src/frontend/components/field--goal-type.tsx
+++ b/src/frontend/components/field--goal-type.tsx
@@ -1,7 +1,7 @@
 export function FieldGoalType({ field_goal_type }) {
   let goalTypeName = "";
   let goalTypeClasses = "";
-  switch (field_goal_type) {
+  switch (field_goal_type.toLowerCase()) {
     case "apg":
       goalTypeName = "Agency priority goal";
       goalTypeClasses = "bg-primary-vivid";
@@ -10,6 +10,10 @@ export function FieldGoalType({ field_goal_type }) {
       goalTypeName = "Strategic goal";
       goalTypeClasses = "bg-base-darkest";
       break;
+    case "national":
+        goalTypeName = "National";
+        goalTypeClasses = "bg-base-darkest";
+        break;
     default:
       goalTypeName = "Default"
       goalTypeClasses = "bg-base";

--- a/src/frontend/components/field--period.tsx
+++ b/src/frontend/components/field--period.tsx
@@ -6,7 +6,7 @@ export function FieldPeriod({field_period}) {
       </span>
     )
   }
-  let period = field_period.name.replace(/^[^0-9]+/, '');
+  let period = field_period.name.startsWith("FY") ? field_period.name.replace(/^[^0-9]+/, '') : field_period.name;
   return (
     <span className={`border padding-x-105 font-sans-3xs radius-pill`}>
       {period}

--- a/src/frontend/components/view--goal-facets.tsx
+++ b/src/frontend/components/view--goal-facets.tsx
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react';
+
+const ViewGoalFacets = ({filter_options, handleSearch}) => {
+  const facetKeys = filter_options ? Object.keys(filter_options) : [];
+
+  const [checkedFacets, setCheckedFacets] = useState([])
+
+  function handleCheck(facetKey) {
+    if (checkedFacets.includes(facetKey)) {
+      const newFacetList = checkedFacets.filter((facet) => {
+        if (facet == facetKey) {
+          return null;
+        }
+        return facet;
+      })
+      setCheckedFacets(newFacetList)
+    } else {
+      setCheckedFacets([...checkedFacets, facetKey])
+    }
+  }
+
+  useEffect(() => {
+    handleSearch(null, checkedFacets)
+  }, [checkedFacets, handleSearch])
+
+  return(
+    <div>
+      {facetKeys.map(( facetKey ) => (
+        <div className="usa-checkbox" key={facetKey.replace(/ /g,'')}>
+          <input
+            className="usa-checkbox__input"
+            id={`${facetKey.replace(/ /g,'')}-checkbox`}
+            type="checkbox"
+            name="goal-search-facets"
+            value={facetKey}
+            onChange={() => handleCheck(facetKey)}
+            checked={checkedFacets.includes(facetKey)}
+            disabled={checkedFacets.length > 0 && !checkedFacets.includes(facetKey) ? true : false}
+          />
+          <label
+            className="usa-checkbox__label"
+            htmlFor={`${facetKey.replace(/ /g,'')}-checkbox`}
+          >
+            {facetKey}
+          </label>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default ViewGoalFacets;

--- a/src/frontend/components/view--goal-search--results.tsx
+++ b/src/frontend/components/view--goal-search--results.tsx
@@ -1,0 +1,47 @@
+import { FormEvent } from "react";
+import { Search } from "@trussworks/react-uswds";
+
+interface ViewGoalSearchResultsProps {
+  
+}
+
+export function ViewGoalSearchResults({}: ViewGoalSearchResultsProps) {
+
+  return (
+    <div>
+      results
+    </div>
+  );
+}
+
+// {/* {displayGoals?.length ? (
+//         <ul className="usa-card-group">
+//           {displayGoals && displayGoals.map((goal) => (
+//             <li
+//               key={goal.id}
+//               className="usa-card tablet-lg:grid-col-6 desktop:grid-col-4"
+//             >
+//               <NodeGoalCard goal={goal} />
+//             </li>
+//           ))}
+//         </ul>
+//       ) : (
+//           <div className="usa-alert usa-alert--warning usa-alert--slim">
+//             <div className="usa-alert__body">
+//               <p className="usa-alert__text">
+//                 No matching goals.
+//               </p>
+//             </div>
+//           </div>
+//         )}
+
+//       <div className="grid-row flex-justify-center margin-bottom-205">
+//         {offset < filteredGoalsCount &&
+//           <Button
+//             type="button"
+//             onClick={() => setOffset(offset + 9)}
+//           >
+//             Show more
+//           </Button>
+//         }
+//       </div> */}

--- a/src/frontend/components/view--goal-search.tsx
+++ b/src/frontend/components/view--goal-search.tsx
@@ -5,6 +5,7 @@ import { NodeGoalProps, ViewFilter } from "lib/types";
 import { NodeGoalCard } from "./node--goal--card";
 import { ViewGoalSearchFacet } from "./view--goal-search--facet";
 import { ViewGoalSearchFulltext } from "./view--goal-search--fulltext";
+import { ViewGoalSearchResults } from "./view--goal-search--results";
 
 interface ViewGoalSearch {
   goals: Array<NodeGoalProps>,
@@ -13,11 +14,39 @@ interface ViewGoalSearch {
   total: number
 }
 
+async function getData(fulltext: string) {
+  const url = `/api/goal-search?fulltext=${fulltext}`;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Response status: ${response.status}`);
+    }
+    
+    const { data } = await response.json();
+    console.log(data);
+    return {
+      goals: data?.goalsGraphql1?.results ?? [],
+      filters: data?.goalsGraphql1?.filters ?? [],
+      total: data?.goalsGraphql1?.pageInfo?.total ?? 0,
+      description: data?.goalsGraphql1?.description ?? "",
+    };
+  } catch (error) {
+    console.error(error.message);
+  }
+  
+}
+
 export default function GoalsSearchView({ filters, goals, total, description }: ViewGoalSearch) {
+<<<<<<< HEAD
   const offsetAmount = 15;
 
   const [fulltext, setFulltext] = useState(filters[0].value ? filters[0].value : "")
   const [facets] = useState([...Object.keys(filters[1].options)])
+=======
+  const [fulltext, setFulltext] = useState(filters[0]?.value ? filters[0].value : "")
+  const [displayGoals, setDisplayGoals] = useState(goals)
+  const [facets] = useState(filters[1] ? [...Object.keys(filters[1]?.options)] : [])
+>>>>>>> 7a191ae (Initial nextjs api endpoint commit)
   const [search, setSearch] = useState(false);
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [offset, setOffset] = useState(offsetAmount);
@@ -26,9 +55,29 @@ export default function GoalsSearchView({ filters, goals, total, description }: 
   const [filteredGoals, setFilteredGoals] = useState([...goals])
   const [filteredGoalsCount, setFilteredGoalsCount] = useState(total)
 
-  function handleSearch(e: FormEvent) {
+  async function handleSearch(e: FormEvent) {
     e.preventDefault()
-    setSearch(true)
+    const url = `/api/goal-search?fulltext=${fulltext}`;
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Response status: ${response.status}`);
+      }
+    
+      const { data } = await response.json();
+      console.log(data)
+      setDisplayGoals(data?.goalsGraphql1?.results ?? [])
+      setFilteredGoalsCount(data?.goalsGraphql1?.pageInfo?.total ?? 0)
+      // console.log(data);
+      // return {
+      //   goals: data?.goalsGraphql1?.results ?? [],
+      //   filters: data?.goalsGraphql1?.filters ?? [],
+      //   total: data?.goalsGraphql1?.pageInfo?.total ?? 0,
+      //   description: data?.goalsGraphql1?.description ?? "",
+      // };
+    } catch (error) {
+      console.error(error.message);
+    }
   }
 
   function updateTopicFilters(topic) {

--- a/src/frontend/components/view--goal-search.tsx
+++ b/src/frontend/components/view--goal-search.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, FormEvent, useCallback } from "react";
+import { useState, useEffect, useRef, FormEvent, useCallback } from "react";
 import { Button } from "@trussworks/react-uswds";
 import Masonry, {ResponsiveMasonry} from "react-responsive-masonry"
 import { NodeGoalProps, ViewFilter } from "lib/types";
@@ -6,6 +6,7 @@ import { NodeGoalCard } from "./node--goal--card";
 import { ViewGoalSearchFacet } from "./view--goal-search--facet";
 import { ViewGoalSearchFulltext } from "./view--goal-search--fulltext";
 import { ViewGoalSearchResults } from "./view--goal-search--results";
+import ViewGoalFacets from "./view--goal-facets";
 
 interface ViewGoalSearch {
   goals: Array<NodeGoalProps>,
@@ -14,50 +15,21 @@ interface ViewGoalSearch {
   total: number
 }
 
-async function getData(fulltext: string) {
-  const url = `/api/goal-search?fulltext=${fulltext}`;
-  try {
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`Response status: ${response.status}`);
-    }
-    
-    const { data } = await response.json();
-    console.log(data);
-    return {
-      goals: data?.goalsGraphql1?.results ?? [],
-      filters: data?.goalsGraphql1?.filters ?? [],
-      total: data?.goalsGraphql1?.pageInfo?.total ?? 0,
-      description: data?.goalsGraphql1?.description ?? "",
-    };
-  } catch (error) {
-    console.error(error.message);
-  }
-  
-}
-
 export default function GoalsSearchView({ filters, goals, total, description }: ViewGoalSearch) {
-<<<<<<< HEAD
   const offsetAmount = 15;
-
-  const [fulltext, setFulltext] = useState(filters[0].value ? filters[0].value : "")
-  const [facets] = useState([...Object.keys(filters[1].options)])
-=======
-  const [fulltext, setFulltext] = useState(filters[0]?.value ? filters[0].value : "")
+  const [fulltext, setFulltext] = useState(filters[0].value ? filters[0].value : "");
+  const [totalResults, setTotalResults] = useState(total)
   const [displayGoals, setDisplayGoals] = useState(goals)
-  const [facets] = useState(filters[1] ? [...Object.keys(filters[1]?.options)] : [])
->>>>>>> 7a191ae (Initial nextjs api endpoint commit)
-  const [search, setSearch] = useState(false);
+  const [facets, setFacets] = useState(filters[1]?.options ? filters[1].options : [])
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [offset, setOffset] = useState(offsetAmount);
-  const [activeTopics, setActiveTopics] = useState([])
-  const [notDisabledTopics, setNotDisabledTopics] = useState([])
-  const [filteredGoals, setFilteredGoals] = useState([...goals])
-  const [filteredGoalsCount, setFilteredGoalsCount] = useState(total)
-
-  async function handleSearch(e: FormEvent) {
-    e.preventDefault()
-    const url = `/api/goal-search?fulltext=${fulltext}`;
+  
+  const handleSearch = useCallback(async (e: FormEvent, facets: Array<string> = []) => {
+    if (e) {
+      e.preventDefault();
+    }
+    const url = `/api/goal-search?fulltext=${fulltext}&facets=${facets}`;
+    setOffset(offsetAmount)
     try {
       const response = await fetch(url);
       if (!response.ok) {
@@ -65,112 +37,16 @@ export default function GoalsSearchView({ filters, goals, total, description }: 
       }
     
       const { data } = await response.json();
-      console.log(data)
-      setDisplayGoals(data?.goalsGraphql1?.results ?? [])
-      setFilteredGoalsCount(data?.goalsGraphql1?.pageInfo?.total ?? 0)
-      // console.log(data);
-      // return {
-      //   goals: data?.goalsGraphql1?.results ?? [],
-      //   filters: data?.goalsGraphql1?.filters ?? [],
-      //   total: data?.goalsGraphql1?.pageInfo?.total ?? 0,
-      //   description: data?.goalsGraphql1?.description ?? "",
-      // };
+      setDisplayGoals(data?.goalsGraphql1?.results ?? []);
+      setTotalResults(data?.goalsGraphql1?.pageInfo.total);
+      setFacets(data?.goalsGraphql1?.filters[1].options)
     } catch (error) {
       console.error(error.message);
     }
-  }
+  }, [fulltext])
 
-  function updateTopicFilters(topic) {
-    let currentFilters = [...activeTopics];
-    const topicIndex = currentFilters.indexOf(topic);
-    if (topicIndex > -1) {
-      currentFilters.splice(topicIndex, 1);
-    } else {
-      currentFilters.push(topic)
-    }
-    setActiveTopics(currentFilters)
-  }
-
-  const filterGoals = useCallback (
-    (resetOffset = false) => {
-      let currentGoals = [...goals];
-      let notDisabled = []
-      if(fulltext.length > 0) {
-        currentGoals = currentGoals.filter((goal) => {
-          let hasFulltext = false;
-          const searchFields = [goal?.body?.value, goal.title];
-          searchFields.forEach((field) => {
-            if(field && field.toLowerCase().includes(fulltext.toLowerCase())) {
-              hasFulltext = true
-              if (goal.topics?.length) {
-                goal.topics.forEach((topic) => {
-                  if(!notDisabled.includes(topic.name)) {
-                    notDisabled.push(topic.name)
-                  }
-                })
-              }
-            }
-          })
-
-          if(hasFulltext ) {
-            
-            return goal
-          } else {
-            return null
-          }
-        })
-        
-      }
-
-      if (activeTopics.length > 0) {
-        currentGoals = currentGoals.filter((goal) => {
-          let hasActiveTopic = false
-          if (!goal.topics) {
-            return null;
-          }
-          goal.topics.forEach((topic) => {
-            if(activeTopics.indexOf(topic.name) > -1) {
-              hasActiveTopic = true
-            }
-          })
-          if(hasActiveTopic) {
-            return goal
-          } else {
-            return null
-          }
-        })
-      }
-
-      setNotDisabledTopics(notDisabled)
-      setFilteredGoalsCount(currentGoals.length)
-      
-      if (resetOffset) {
-        currentGoals = currentGoals.slice(0, offsetAmount);
-        setOffset(offsetAmount)
-      } else {
-        currentGoals = currentGoals.slice(0, offset);
-      }
-      setFilteredGoals(currentGoals)
-      setSearch(false)
-    }, [activeTopics, fulltext, goals,offset]
-  );
-
-  useEffect(() => {
-    if(search) {
-      filterGoals(true)
-    }
-  }, [search, filterGoals])
-
-  useEffect(() => {
-    filterGoals(true)
-  }, [activeTopics, filterGoals])
-
-  useEffect(() => {
-    filterGoals()
-  }, [offset, filterGoals])
 
   const masonryBP = filtersOpen ? {350: 1, 750: 2, 1400: 3} : {350: 1, 750: 2, 1060: 3, 1400: 4};
-
   return (
     <div>
       <div className="grid-row flex-justify-center">
@@ -182,43 +58,19 @@ export default function GoalsSearchView({ filters, goals, total, description }: 
         setFulltext={setFulltext}
         handleSearch={handleSearch}
       />
-      {/* <ul className="add-list-reset grid-row flex-justify-center margin-bottom-205">
-        {facets.length ? (
-          facets.map((topic) => (
-            <li
-              className="margin-bottom-05"
-              key={topic.replace( /\s/g, '')}
-            >
-              <ViewGoalSearchFacet
-                topic={topic}
-                notDisabledTopics={notDisabledTopics}
-                activeTopics={activeTopics}
-                updateTopicFilters={updateTopicFilters}
-              />
-            </li>
-          ))
-        ) : (
-          <div className="usa-alert usa-alert--warning usa-alert--slim">
-            <div className="usa-alert__body">
-              <p className="usa-alert__text">
-                No facets found.
-              </p>
-            </div>
-          </div>
-        )}
-      </ul> */}
+      
       <div className="grid-row">
         <div className={`side-bar ${filtersOpen ? "" : "filters-closed"}`}>
-          <p>iajghjgojg</p>
+          <ViewGoalFacets filter_options={facets} handleSearch={handleSearch} />
         </div>
         <div className="content-area">
-          {filteredGoals?.length ? (
+          {displayGoals?.length ? (
           <ResponsiveMasonry
               columnsCountBreakPoints={masonryBP}
               gutterBreakpoints={{350: "12px", 750: "16px", 900: "24px"}}
           >
               <Masonry>
-              {filteredGoals.map((goal) => (
+              {displayGoals.slice(0, offset).map((goal) => (
                   <NodeGoalCard key={goal.id} goal={goal} />
                 ))}
               </Masonry>
@@ -226,7 +78,7 @@ export default function GoalsSearchView({ filters, goals, total, description }: 
           
         ) : (
             <div className="usa-alert usa-alert--warning usa-alert--slim">
-              <div className="usa-alert__body">
+              <div className="usa-alerjt__body">
                 <p className="usa-alert__text">
                   No matching goals.
                 </p>
@@ -235,7 +87,7 @@ export default function GoalsSearchView({ filters, goals, total, description }: 
           )}
 
         <div className="grid-row flex-justify-center margin-bottom-205">
-          {offset < filteredGoalsCount &&
+          {offset < totalResults &&
             <Button
               type="button"
               onClick={() => setOffset(offset + offsetAmount)}

--- a/src/frontend/lib/graphqlQueries.ts
+++ b/src/frontend/lib/graphqlQueries.ts
@@ -1,4 +1,4 @@
-export const nodeQueries = {
+export const graphqlQueries = {
   nodeGoal: (path: string) => (
     `query NodeGoalQuery {
       route(path: "${path}") {
@@ -57,33 +57,64 @@ export const nodeQueries = {
       }
     }`
   ),
-}
-
-export const strategicPlanQueries = {
   planNodeByAgency: (id: number) => (
-   `query StrategicPlansByAgency {
-  strategicPlansByAgencyGraphql1(filter: {field_agency_target_id: ${id}}) {
-    pageInfo {
-      total
-    }
-    results {
-      ... on NodePlan {
-        id
-        title
-        link {
-          url
-        }
-        goals {
-          ... on NodeGoal {
-            id
-            title
-            goalType
-            path
+    `query StrategicPlansByAgency {
+   strategicPlansByAgencyGraphql1(filter: {field_agency_target_id: ${id}}) {
+     pageInfo {
+       total
+     }
+     results {
+       ... on NodePlan {
+         id
+         title
+         link {
+           url
+         }
+         goals {
+           ... on NodeGoal {
+             id
+             title
+             goalType
+             path
+           }
+         }
+       }
+     }
+   }
+ }`
+  ),
+  goalsView: (fulltext: string, facets: Array<string>) => (
+    `query GoalsQuery {
+        goalsGraphql1(filter: {
+          aggregated_field: "${fulltext}",
+          Topics: [${facets}],
+        }) {
+          pageInfo {
+            total
+          }
+          filters {
+            options
+            value
+          }
+          description
+          results {
+            ... on NodeGoal {
+              id
+              title
+              path
+              body {
+                value
+              }
+              
+              topics {
+                ... on TermTopic {
+                  id
+                  name
+                }
+              }
+            }
           }
         }
-      }
-    }
-  }
-}`
+      }`
   ),
 }

--- a/src/frontend/lib/graphqlQueries.ts
+++ b/src/frontend/lib/graphqlQueries.ts
@@ -83,38 +83,62 @@ export const graphqlQueries = {
    }
  }`
   ),
-  goalsView: (fulltext: string, facets: Array<string>) => (
+  goalsView: (fulltext: string | string[], facets: string | string[]) => (
     `query GoalsQuery {
-        goalsGraphql1(filter: {
-          aggregated_field: "${fulltext}",
-          Topics: [${facets}],
-        }) {
-          pageInfo {
-            total
-          }
-          filters {
-            options
-            value
-          }
-          description
-          results {
-            ... on NodeGoal {
-              id
-              title
-              path
-              body {
-                value
+      goalsGraphql1(filter: {
+        aggregated_field: "${fulltext}",
+        Topics: ${JSON.stringify(facets)},
+      }) {
+        pageInfo {
+          total
+        }
+        filters {
+          options
+          value
+        }
+        description
+        results {
+          ... on NodeGoal {
+            id
+            title
+            path
+            goalType
+            topics {
+              ... on TermTopic {
+                id
+                name
               }
-              
-              topics {
-                ... on TermTopic {
-                  id
-                  name
+            }
+            plan {
+              ... on NodePlan {
+                id
+                agency {
+                  ... on NodeAgency {
+                    id
+                    acronym
+                    logo {
+                      ... on MediaImage {
+                        id
+                        name
+                        mediaImage {
+                          url
+                        }
+                      }
+                    }
+                    title
+                  }
                 }
+              }
+            }
+            period {
+              ... on StoragePeriod {
+                id
+                name
               }
             }
           }
         }
-      }`
+      }
+    }`
   ),
 }

--- a/src/frontend/pages/[...slug].tsx
+++ b/src/frontend/pages/[...slug].tsx
@@ -8,7 +8,7 @@ import { NodeBasicPage } from "components/node--basic-page";
 import { NodeAgency } from "../components/node--agency";
 import { NodeGoal } from "components/node--goal";
 import { Layout } from "components/layout";
-import { nodeQueries, strategicPlanQueries } from "./api/node-queries";
+import { graphqlQueries } from "../lib/graphqlQueries";
 
 const RESOURCE_TYPES = ["node--page", "node--article", "node--agency", "node--goal"];
 
@@ -109,7 +109,7 @@ export async function getStaticProps(
       method: "POST",
       withAuth: true, // Make authenticated requests using OAuth.
       body: JSON.stringify({
-        query: nodeQueries.nodeGoal(path?.entity?.path),
+        query: graphqlQueries.nodeGoal(path?.entity?.path),
       }),
     });
     const { data } = await response.json();
@@ -121,7 +121,7 @@ export async function getStaticProps(
       method: "POST",
       withAuth: true, // Make authenticated requests using OAuth.
       body: JSON.stringify({
-        query: strategicPlanQueries.planNodeByAgency(agencyId),
+        query: graphqlQueries.planNodeByAgency(agencyId),
       }),
     });
     const { data } = await response.json();

--- a/src/frontend/pages/api/goal-search.ts
+++ b/src/frontend/pages/api/goal-search.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { drupal } from "lib/drupal";
+import { graphqlQueries } from "lib/graphqlQueries";
+
+type ResponseData = {
+  message: string;
+  data: any;
+}
+ 
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseData>
+) {
+  const graphqlUrl = drupal.buildUrl("/graphql");
+  console.log("q:", req.query)
+  const fulltext = req.query.fulltext ? req.query.fulltext : ""
+  const response = await drupal.fetch(graphqlUrl.toString(), {
+    method: "POST",
+    withAuth: true, // Make authenticated requests using OAuth.
+    body: JSON.stringify({
+      query: graphqlQueries.goalsView(fulltext, []),
+    }),
+  });
+  const { data } = await response.json();
+  console.log(data)
+  res.status(200).json({ message: 'Hello from Next.js!', data: data })
+}

--- a/src/frontend/pages/api/goal-search.ts
+++ b/src/frontend/pages/api/goal-search.ts
@@ -12,16 +12,15 @@ export default async function handler(
   res: NextApiResponse<ResponseData>
 ) {
   const graphqlUrl = drupal.buildUrl("/graphql");
-  console.log("q:", req.query)
-  const fulltext = req.query.fulltext ? req.query.fulltext : ""
+  const fulltext = req.query.fulltext ? req.query.fulltext : "";
+  const facets = req.query.facets ? req.query.facets : [];
   const response = await drupal.fetch(graphqlUrl.toString(), {
     method: "POST",
     withAuth: true, // Make authenticated requests using OAuth.
     body: JSON.stringify({
-      query: graphqlQueries.goalsView(fulltext, []),
+      query: graphqlQueries.goalsView(fulltext, facets),
     }),
   });
   const { data } = await response.json();
-  console.log(data)
   res.status(200).json({ message: 'Hello from Next.js!', data: data })
 }

--- a/src/frontend/pages/index.tsx
+++ b/src/frontend/pages/index.tsx
@@ -4,6 +4,7 @@ import { drupal } from "lib/drupal";
 import { Layout } from "components/layout";
 import GoalsSearchView from "components/view--goal-search";
 import { NodeGoalProps, ViewFilter } from "lib/types";
+import { graphqlQueries } from "lib/graphqlQueries";
 
 interface IndexPageProps {
   goals: Array<NodeGoalProps>,
@@ -19,65 +20,10 @@ export const getStaticProps = async () => {
     method: "POST",
     withAuth: true, // Make authenticated requests using OAuth.
     body: JSON.stringify({
-      query: `query GoalsQuery {
-  goalsGraphql1 {
-    description
-    results {
-      ... on NodeGoal {
-        id
-        title
-        goalType
-        path
-        body {
-          value
-        }
-        topics {
-          ... on TermTopic {
-            id
-            name
-          }
-        }
-        plan {
-          ... on NodePlan {
-            id
-            agency {
-              ... on NodeAgency {
-                id
-                title
-                acronym
-                logo {
-                  ... on MediaImage {
-                    id
-                    name
-                    mediaImage {
-                      url
-                      alt
-                      title
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-        period {
-          ... on StoragePeriod {
-            id
-            name
-          }
-        }
-      }
-    }
-    filters {
-      options
-      value
-    }
-  }
-}`,
+      query: graphqlQueries.goalsView("", []),
     }),
   });
   const { data } = await response.json();
-  
   return {
     props: {
       goals: data?.goalsGraphql1?.results ?? [],
@@ -89,7 +35,7 @@ export const getStaticProps = async () => {
 };
 
 export default function IndexPage(props: IndexPageProps) {
-
+  console.log(props)
   return (
     <Layout>
       <Head>
@@ -101,10 +47,10 @@ export default function IndexPage(props: IndexPageProps) {
       </Head>
       <div className="">
         <GoalsSearchView
-           filters={props.filters}
-           goals={props.goals}
-           total={props.total}
-           description={props.description}
+          filters={props.filters}
+          goals={props.goals}
+          total={props.total}
+          description={props.description}
         />
       </div>
     </Layout>

--- a/src/frontend/pages/index.tsx
+++ b/src/frontend/pages/index.tsx
@@ -35,7 +35,6 @@ export const getStaticProps = async () => {
 };
 
 export default function IndexPage(props: IndexPageProps) {
-  console.log(props)
   return (
     <Layout>
       <Head>


### PR DESCRIPTION
This PR aims to create a NextJS api endpoint that can update the homepage goals search. With NextJS Drupal, each request for information needs authorization credentials passed with it. NextJS uses environmental variables to do this when building the site with functions like getStaticProps. These credentials are never passed to the browser, so updating the site with new data from the view can't be done like a normal React application where you just fetch some new data. 

In NextJS, using the api subfolder in the pages folder, you can create API end points that live on the server part of the NextJS application. These pages are never sent to the browser, but can be used be the browser part of the site to access the Drupal site. In this PR I've added the endpoint /api/goal-search which can take a query of fulltext. This endpoint then works similar to the getStaticProps on page load, when a request hits the endpoint, it sends a graphql query to the Drupal site with the auth information and returns the information through my new endpoint to the browser application. When using the application, if you use the goals search, you will never see the Drupal endpoint, only the NextJS api endpoint I created. 