### PR TITLE
Tag all plan content with an administration

### DIFF
--- a/config/core.entity_form_display.node.goal.default.yml
+++ b/config/core.entity_form_display.node.goal.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_form_mode.node.inline
     - field.field.node.goal.body
+    - field.field.node.goal.field_administration
     - field.field.node.goal.field_goal_type
     - field.field.node.goal.field_image
     - field.field.node.goal.field_objectives
@@ -113,7 +114,7 @@ content:
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 3
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -175,13 +176,13 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 4
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 5
+    weight: 4
     region: content
     settings:
       display_label: true
@@ -196,7 +197,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 2
+    weight: 1
     region: content
     settings:
       match_operator: CONTAINS
@@ -205,5 +206,6 @@ content:
       placeholder: ''
     third_party_settings: {  }
 hidden:
+  field_administration: true
   promote: true
   sticky: true

--- a/config/core.entity_form_display.node.goal.inline.yml
+++ b/config/core.entity_form_display.node.goal.inline.yml
@@ -87,8 +87,8 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
-  field_image: true
   field_administration: true
+  field_image: true
   field_objectives: true
   field_plan: true
   path: true

--- a/config/core.entity_form_display.node.goal.inline.yml
+++ b/config/core.entity_form_display.node.goal.inline.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_form_mode.node.inline
     - field.field.node.goal.body
+    - field.field.node.goal.field_administration
     - field.field.node.goal.field_goal_type
     - field.field.node.goal.field_image
     - field.field.node.goal.field_objectives
@@ -87,6 +88,7 @@ content:
 hidden:
   created: true
   field_image: true
+  field_administration: true
   field_objectives: true
   field_plan: true
   path: true

--- a/config/core.entity_form_display.node.objective.default.yml
+++ b/config/core.entity_form_display.node.objective.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_form_mode.storage.inline
     - field.field.node.objective.body
+    - field.field.node.objective.field_administration
     - field.field.node.objective.field_agency
     - field.field.node.objective.field_division
     - field.field.node.objective.field_goal
@@ -88,7 +89,7 @@ content:
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 9
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -140,13 +141,13 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 10
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 11
+    weight: 4
     region: content
     settings:
       display_label: true
@@ -161,7 +162,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 8
+    weight: 1
     region: content
     settings:
       match_operator: CONTAINS
@@ -170,5 +171,6 @@ content:
       placeholder: ''
     third_party_settings: {  }
 hidden:
+  field_administration: true
   promote: true
   sticky: true

--- a/config/core.entity_form_display.node.objective.inline.yml
+++ b/config/core.entity_form_display.node.objective.inline.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_form_mode.node.inline
     - core.entity_form_mode.storage.inline
     - field.field.node.objective.body
+    - field.field.node.objective.field_administration
     - field.field.node.objective.field_agency
     - field.field.node.objective.field_division
     - field.field.node.objective.field_goal
@@ -76,6 +77,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_administration: true
   field_goal: true
   path: true
   promote: true

--- a/config/core.entity_form_display.node.report.default.yml
+++ b/config/core.entity_form_display.node.report.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.report.body
+    - field.field.node.report.field_administration
     - field.field.node.report.field_file
     - field.field.node.report.field_goals
     - field.field.node.report.field_link
@@ -126,5 +127,6 @@ content:
       placeholder: ''
     third_party_settings: {  }
 hidden:
+  field_administration: true
   promote: true
   sticky: true

--- a/config/core.entity_form_display.storage.indicator.default.yml
+++ b/config/core.entity_form_display.storage.indicator.default.yml
@@ -132,7 +132,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_administration: true
   name: true
   status: true
   user_id: true
-  field_administration: true

--- a/config/core.entity_form_display.storage.indicator.default.yml
+++ b/config/core.entity_form_display.storage.indicator.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_form_mode.storage.inline
+    - field.field.storage.indicator.field_administration
     - field.field.storage.indicator.field_description
     - field.field.storage.indicator.field_dimension
     - field.field.storage.indicator.field_divisions
@@ -28,7 +29,7 @@ third_party_settings:
       label: Details
       region: content
       parent_name: ''
-      weight: 5
+      weight: 4
       format_type: html_element
       format_settings:
         classes: form--inline
@@ -50,7 +51,7 @@ mode: default
 content:
   field_description:
     type: text_textarea
-    weight: 4
+    weight: 3
     region: content
     settings:
       rows: 5
@@ -80,7 +81,7 @@ content:
     third_party_settings: {  }
   field_measurements:
     type: inline_entity_form_complex_table_view_mode
-    weight: 8
+    weight: 5
     region: content
     settings:
       form_mode: inline
@@ -98,7 +99,7 @@ content:
     third_party_settings: {  }
   field_notes:
     type: text_textarea
-    weight: 9
+    weight: 6
     region: content
     settings:
       rows: 5
@@ -134,3 +135,4 @@ hidden:
   name: true
   status: true
   user_id: true
+  field_administration: true

--- a/config/core.entity_form_display.storage.indicator.inline.yml
+++ b/config/core.entity_form_display.storage.indicator.inline.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_form_mode.storage.inline
+    - field.field.storage.indicator.field_administration
     - field.field.storage.indicator.field_description
     - field.field.storage.indicator.field_dimension
     - field.field.storage.indicator.field_divisions
@@ -103,6 +104,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_administration: true
   field_notes: true
   field_objective: true
   field_plan: true

--- a/config/core.entity_view_display.node.goal.default.yml
+++ b/config/core.entity_view_display.node.goal.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.goal.body
+    - field.field.node.goal.field_administration
     - field.field.node.goal.field_goal_type
     - field.field.node.goal.field_image
     - field.field.node.goal.field_objectives
@@ -34,7 +35,7 @@ content:
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 6
+    weight: 5
     region: content
   field_image:
     type: media_thumbnail
@@ -53,7 +54,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 7
+    weight: 6
     region: content
   field_period:
     type: entity_reference_label
@@ -61,7 +62,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 3
+    weight: 2
     region: content
   field_plan:
     type: entity_reference_label
@@ -69,7 +70,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 4
+    weight: 3
     region: content
   field_topics:
     type: entity_reference_label
@@ -77,7 +78,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 5
+    weight: 4
     region: content
   links:
     settings: {  }
@@ -85,4 +86,5 @@ content:
     weight: 0
     region: content
 hidden:
+  field_administration: true
   search_api_excerpt: true

--- a/config/core.entity_view_display.node.goal.full.yml
+++ b/config/core.entity_view_display.node.goal.full.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.goal.body
+    - field.field.node.goal.field_administration
     - field.field.node.goal.field_goal_type
     - field.field.node.goal.field_image
     - field.field.node.goal.field_objectives
@@ -67,6 +68,7 @@ content:
     weight: 0
     region: content
 hidden:
+  field_administration: true
   field_plan: true
   field_topics: true
   search_api_excerpt: true

--- a/config/core.entity_view_display.node.goal.ief_table.yml
+++ b/config/core.entity_view_display.node.goal.ief_table.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.ief_table
     - field.field.node.goal.body
+    - field.field.node.goal.field_administration
     - field.field.node.goal.field_goal_type
     - field.field.node.goal.field_image
     - field.field.node.goal.field_objectives
@@ -45,6 +46,7 @@ content:
     weight: 0
     region: content
 hidden:
+  field_administration: true
   field_image: true
   field_objectives: true
   field_plan: true

--- a/config/core.entity_view_display.node.objective.card.yml
+++ b/config/core.entity_view_display.node.objective.card.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.card
     - field.field.node.objective.body
+    - field.field.node.objective.field_administration
     - field.field.node.objective.field_agency
     - field.field.node.objective.field_division
     - field.field.node.objective.field_goal
@@ -33,6 +34,7 @@ content:
     region: content
 hidden:
   body: true
+  field_administration: true
   field_agency: true
   field_goal: true
   field_indicators: true

--- a/config/core.entity_view_display.node.objective.default.yml
+++ b/config/core.entity_view_display.node.objective.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.objective.body
+    - field.field.node.objective.field_administration
     - field.field.node.objective.field_agency
     - field.field.node.objective.field_division
     - field.field.node.objective.field_goal
@@ -19,6 +20,7 @@ mode: default
 content: {  }
 hidden:
   body: true
+  field_administration: true
   field_agency: true
   field_division: true
   field_goal: true

--- a/config/core.entity_view_display.node.objective.full.yml
+++ b/config/core.entity_view_display.node.objective.full.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.objective.body
+    - field.field.node.objective.field_administration
     - field.field.node.objective.field_agency
     - field.field.node.objective.field_division
     - field.field.node.objective.field_goal
@@ -45,6 +46,7 @@ content:
     region: content
 hidden:
   body: true
+  field_administration: true
   field_goal: true
   field_objective_type: true
   links: true

--- a/config/core.entity_view_display.node.objective.ief_table.yml
+++ b/config/core.entity_view_display.node.objective.ief_table.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.ief_table
     - field.field.node.objective.body
+    - field.field.node.objective.field_administration
     - field.field.node.objective.field_agency
     - field.field.node.objective.field_division
     - field.field.node.objective.field_goal
@@ -33,6 +34,7 @@ content:
     region: content
 hidden:
   body: true
+  field_administration: true
   field_agency: true
   field_division: true
   field_goal: true

--- a/config/core.entity_view_display.node.report.default.yml
+++ b/config/core.entity_view_display.node.report.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.report.body
+    - field.field.node.report.field_administration
     - field.field.node.report.field_file
     - field.field.node.report.field_goals
     - field.field.node.report.field_link
@@ -24,7 +25,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 101
+    weight: 2
     region: content
   field_file:
     type: entity_reference_label
@@ -32,7 +33,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 108
+    weight: 6
     region: content
   field_goals:
     type: entity_reference_label
@@ -40,7 +41,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 107
+    weight: 5
     region: content
   field_link:
     type: link
@@ -52,7 +53,7 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 103
+    weight: 3
     region: content
   field_period:
     type: entity_reference_label
@@ -60,7 +61,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 106
+    weight: 4
     region: content
   field_plan:
     type: entity_reference_label
@@ -68,12 +69,13 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 4
+    weight: 0
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 100
+    weight: 1
     region: content
 hidden:
+  field_administration: true
   search_api_excerpt: true

--- a/config/core.entity_view_display.node.report.full.yml
+++ b/config/core.entity_view_display.node.report.full.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.report.body
+    - field.field.node.report.field_administration
     - field.field.node.report.field_file
     - field.field.node.report.field_goals
     - field.field.node.report.field_link
@@ -38,6 +39,7 @@ content:
     region: content
 hidden:
   body: true
+  field_administration: true
   field_file: true
   field_goals: true
   field_period: true

--- a/config/core.entity_view_display.storage.indicator.default.yml
+++ b/config/core.entity_view_display.storage.indicator.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.storage.indicator.field_administration
     - field.field.storage.indicator.field_description
     - field.field.storage.indicator.field_dimension
     - field.field.storage.indicator.field_divisions
@@ -20,6 +21,14 @@ targetEntityType: storage
 bundle: indicator
 mode: default
 content:
+  field_administration:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 4
+    region: content
   field_description:
     type: text_default
     label: hidden

--- a/config/core.entity_view_display.storage.indicator.ief_table.yml
+++ b/config/core.entity_view_display.storage.indicator.ief_table.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.storage.ief_table
+    - field.field.storage.indicator.field_administration
     - field.field.storage.indicator.field_description
     - field.field.storage.indicator.field_dimension
     - field.field.storage.indicator.field_divisions
@@ -29,6 +30,7 @@ content:
     weight: 1
     region: content
 hidden:
+  field_administration: true
   field_dimension: true
   field_divisions: true
   field_keyness: true

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -68,6 +68,7 @@ module:
   path_alias: 0
   pgov_indicator: 0
   pgov_migrate: 0
+  pgov_plan: 0
   rest: 0
   search: 0
   search_api: 0

--- a/config/field.field.node.goal.field_administration.yml
+++ b/config/field.field.node.goal.field_administration.yml
@@ -1,0 +1,29 @@
+uuid: 0e1f4de1-96d9-4f4f-ad93-df26e9c43ccc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_administration
+    - node.type.goal
+    - storage.storage_type.administration
+id: node.goal.field_administration
+field_name: field_administration
+entity_type: node
+bundle: goal
+label: Administration
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:storage'
+  handler_settings:
+    target_bundles:
+      administration: administration
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.objective.field_administration.yml
+++ b/config/field.field.node.objective.field_administration.yml
@@ -1,0 +1,29 @@
+uuid: a8aeafae-d486-46db-9c82-af8ca770a7a3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_administration
+    - node.type.objective
+    - storage.storage_type.administration
+id: node.objective.field_administration
+field_name: field_administration
+entity_type: node
+bundle: objective
+label: Administration
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:storage'
+  handler_settings:
+    target_bundles:
+      administration: administration
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.report.field_administration.yml
+++ b/config/field.field.node.report.field_administration.yml
@@ -1,0 +1,29 @@
+uuid: 71a38433-1704-4afb-8e1f-cdd6790c5057
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_administration
+    - node.type.report
+    - storage.storage_type.administration
+id: node.report.field_administration
+field_name: field_administration
+entity_type: node
+bundle: report
+label: Administration
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:storage'
+  handler_settings:
+    target_bundles:
+      administration: administration
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.storage.indicator.field_administration.yml
+++ b/config/field.field.storage.indicator.field_administration.yml
@@ -1,0 +1,29 @@
+uuid: b9f9b84c-88a3-4c8b-95fd-5e048dc14b29
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.storage.field_administration
+    - storage.storage_type.administration
+    - storage.storage_type.indicator
+id: storage.indicator.field_administration
+field_name: field_administration
+entity_type: storage
+bundle: indicator
+label: Administration
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:storage'
+  handler_settings:
+    target_bundles:
+      administration: administration
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.storage.storage.field_administration.yml
+++ b/config/field.storage.storage.field_administration.yml
@@ -1,0 +1,19 @@
+uuid: 5f9a8370-4540-40a0-88ff-642fa01a0c30
+langcode: en
+status: true
+dependencies:
+  module:
+    - storage
+id: storage.field_administration
+field_name: field_administration
+entity_type: storage
+type: entity_reference
+settings:
+  target_type: storage
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/pgov_plan/README.md
+++ b/web/modules/custom/pgov_plan/README.md
@@ -1,0 +1,37 @@
+## Strategic Plans,  Goals and Objectives
+
+The Strategic plans, goals, and objectives module adds business rules and data
+management to these hierarchical components of a Strategic plan.
+
+### Site architecture and assumptions
+
+Much of the logic is based on the idea that the content is managed in a
+hierarchy:
+
+* A _Strategic Plan_ (Content type) lists one or more _Goals_ as entity
+  references.
+* A _Goal_ (Content type) lists one or more _Objectives_ as entity references.
+* An _Objective_ (Content type) lists one or more _Performance indicators_
+  as entity references.
+* A _Performance indicator_ (Storage) lists one or more _Measurements_
+  (Storage) as entity references.
+
+In each of these cases, the relationship is visible in both directions: _Plan_
+nodes use `field_goals`, a multi-value reference field, to reference _Goal_
+nodes, and _Goal_ nodes reference their parent _Plan_ nodes using a single-value
+`field_plan` reference field. These fields are kept in sync using the
+CER module.
+
+### Custom business rules
+The content structure is set up using standard Sitebuilding practices and Drupal
+core functionality. This module relies on the above-referenced hierarchy to
+enforce some extra business rules:
+
+#### All content references an Administration
+
+All content should be tagged with a presidential administration, so that it can
+be filtered based on the current administration.
+
+Given that `field_administration` is a required field _Plan_, this module uses
+`hook_entity_presave` to ensure that the same value is added to every Goal,
+Objective, and Indicator that falls under that plan.

--- a/web/modules/custom/pgov_plan/pgov_plan.info.yml
+++ b/web/modules/custom/pgov_plan/pgov_plan.info.yml
@@ -1,0 +1,8 @@
+name: 'Strategic plans, goals, and objectives'
+type: module
+description: 'Custom business logic that applies to Strategic plans and their components.'
+package: Custom
+core_version_requirement: ^10 || ^11
+dependencies:
+  - node:node
+  - drupal:storage

--- a/web/modules/custom/pgov_plan/pgov_plan.module
+++ b/web/modules/custom/pgov_plan/pgov_plan.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
 
 /**
  * Implements hook_ENTITY_presave().
@@ -19,7 +20,7 @@ use Drupal\Core\Entity\EntityInterface;
  * the nearest item.
  */
 function pgov_plan_entity_presave(EntityInterface $entity) {
-  if ($entity->hasField('field_administration') && $entity->get('field_administration')->isEmpty()) {
+  if ($entity instanceof FieldableEntityInterface && $entity->hasField('field_administration') && $entity->get('field_administration')->isEmpty()) {
     if ($administration = \Drupal::service('pgov_plan_hierarchy')->getNearestParentEntity($entity, 'administration')) {
       $entity->set('field_administration', ['target_id' => $administration->id()]);
     }

--- a/web/modules/custom/pgov_plan/pgov_plan.module
+++ b/web/modules/custom/pgov_plan/pgov_plan.module
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for Strategic plans, goals, and objectives module.
+ */
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Implements hook_ENTITY_presave().
+ *
+ * Automatically populate field_administration on Goals, Objectives, and
+ * Performance indicators based on the value of field_administration in the
+ * parent plan.
+ *
+ * When field_administration is empty, use the Hierarchy service to traverse
+ * the tree of parents until it reaches the value of field_administration on
+ * the nearest item.
+ */
+function pgov_plan_entity_presave(EntityInterface $entity) {
+  if ($entity->hasField('field_administration') && $entity->get('field_administration')->isEmpty()) {
+    if ($administration = \Drupal::service('pgov_plan_hierarchy')->getNearestParentEntity($entity, 'administration')) {
+      $entity->set('field_administration', ['target_id' => $administration->id()]);
+    }
+  }
+}

--- a/web/modules/custom/pgov_plan/pgov_plan.services.yml
+++ b/web/modules/custom/pgov_plan/pgov_plan.services.yml
@@ -1,0 +1,3 @@
+services:
+  pgov_plan_hierarchy:
+    class: Drupal\pgov_plan\Hierarchy

--- a/web/modules/custom/pgov_plan/src/Hierarchy.php
+++ b/web/modules/custom/pgov_plan/src/Hierarchy.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\pgov_plan;
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Helper functions based to find data based on the hierarchy of Plan content.
+ */
+final class Hierarchy {
+
+  /**
+   * Reference field hierarchy.
+   *
+   * @var array|string[]
+   * A list of entity reference fields, from lowest-to-highest in the hierarchy.
+   */
+  private array $hierarchy = [
+    'field_indicator',
+    'field_objective',
+    'field_goal',
+    'field_plan',
+    'field_administration',
+  ];
+
+  /**
+   * Get the nearest parent in the hierarchy that is of type $bundle.
+   */
+  public function getNearestParentEntity(EntityInterface $entity, $bundle) {
+    foreach ($this->hierarchy as $parent_field) {
+      if ($entity->hasField($parent_field)) {
+
+        // We can't filter if a parent field exists but isn't populated: return.
+        if (!$references = $entity->get($parent_field)->referencedEntities()) {
+          return FALSE;
+        }
+        else {
+          // If the current entity matches the requested bundle, return it.
+          $parent_entity = current($references);
+          if ($parent_entity?->bundle() === $bundle) {
+            return $parent_entity;
+          }
+          else {
+            // Recursively find the next level up.
+            return $this->getNearestParentEntity($parent_entity, $bundle);
+          }
+        }
+      }
+    }
+    // Return FALSE on failure.
+    return FALSE;
+  }
+
+  /**
+   * Return the time period entry for the nearest parent.
+   *
+   * Given that the plan content appears in a nested hierarchy, use the time
+   * period referenced by the parent entity of the current item. If the nearest
+   * parent does not have a time period, look at that parent's parent, and
+   * so-on until the list of parents are exhausted.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The current entity to inspect (or a parent entity, by way of recursion)
+   *
+   * @return false|mixed|void
+   *   A Time period (period) Storage entity or FALSE.
+   */
+  public function getTimePeriod(EntityInterface $entity) {
+    foreach ($this->hierarchy as $parent_field) {
+      if ($entity->hasField($parent_field)) {
+        // We can't filter if a parent field exists but isn't populated: return.
+        if (!$references = $entity->get($parent_field)->referencedEntities()) {
+          return FALSE;
+        }
+        else {
+          $parent_entity = current($references);
+
+          // If the parent has a field_period value, return that.
+          if ($parent_entity?->hasField('field_period')) {
+            if ($period = $parent_entity->get('field_period')
+              ->referencedEntities()) {
+              return current($period);
+            }
+          }
+          // Or, if it has a date range (as on Administration) return that.
+          elseif ($parent_entity?->hasField('field_date_range')) {
+            return $parent_entity;
+          }
+          else {
+            // Recursively find the next level up.
+            return $this->parentTimePeriod($parent_entity);
+          }
+        }
+      }
+    }
+    // Return FALSE on failure.
+    return FALSE;
+  }
+
+}


### PR DESCRIPTION
This will allow us to add an 'Administration' filter that will filter all Plan, Goal, Objective, and Indicator content based on the selected Administration.

* Adds `field_administration` to each of these content types, but does not display it on the front end or edit form
* Adds a helper service to locate antecedent content based on the Plan->Goal->Objective->Indicator hierarchy
* Adds hook_entity_presave to populate field_administration based on the value of the nearest parent.