### PR TITLE
Add sequence indicator to Goals, Objectives, Indicators

### DIFF
--- a/config/core.entity_form_display.node.goal.default.yml
+++ b/config/core.entity_form_display.node.goal.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.goal.field_objectives
     - field.field.node.goal.field_period
     - field.field.node.goal.field_plan
+    - field.field.node.goal.field_sequence
     - field.field.node.goal.field_topics
     - node.type.goal
   module:
@@ -42,6 +43,7 @@ third_party_settings:
       children:
         - field_plan
         - group_administrative
+        - field_sequence
         - title
         - field_topics
         - field_image
@@ -104,7 +106,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 9
+    weight: 10
     region: content
     settings:
       rows: 8
@@ -126,7 +128,7 @@ content:
     third_party_settings: {  }
   field_image:
     type: media_library_widget
-    weight: 8
+    weight: 9
     region: content
     settings:
       media_types: {  }
@@ -161,9 +163,17 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_sequence:
+    type: string_textfield
+    weight: 6
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_topics:
     type: tagify_entity_reference_autocomplete_widget
-    weight: 7
+    weight: 8
     region: content
     settings:
       match_operator: CONTAINS
@@ -189,7 +199,7 @@ content:
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 6
+    weight: 7
     region: content
     settings:
       size: 60

--- a/config/core.entity_form_display.node.goal.default.yml
+++ b/config/core.entity_form_display.node.goal.default.yml
@@ -164,11 +164,10 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_sequence:
-    type: string_textfield
+    type: number
     weight: 6
     region: content
     settings:
-      size: 60
       placeholder: ''
     third_party_settings: {  }
   field_topics:

--- a/config/core.entity_form_display.node.goal.inline.yml
+++ b/config/core.entity_form_display.node.goal.inline.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.goal.field_objectives
     - field.field.node.goal.field_period
     - field.field.node.goal.field_plan
+    - field.field.node.goal.field_sequence
     - field.field.node.goal.field_topics
     - node.type.goal
   module:
@@ -67,6 +68,14 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_sequence:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_topics:
     type: entity_reference_autocomplete_tags
     weight: 3
@@ -79,7 +88,7 @@ content:
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 1
+    weight: 2
     region: content
     settings:
       size: 60
@@ -87,8 +96,8 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
-  field_image: true
   field_administration: true
+  field_image: true
   field_objectives: true
   field_plan: true
   path: true

--- a/config/core.entity_form_display.node.goal.inline.yml
+++ b/config/core.entity_form_display.node.goal.inline.yml
@@ -69,11 +69,10 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_sequence:
-    type: string_textfield
+    type: number
     weight: 1
     region: content
     settings:
-      size: 60
       placeholder: ''
     third_party_settings: {  }
   field_topics:

--- a/config/core.entity_form_display.node.objective.default.yml
+++ b/config/core.entity_form_display.node.objective.default.yml
@@ -142,11 +142,10 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_sequence:
-    type: string_textfield
+    type: number
     weight: 6
     region: content
     settings:
-      size: 60
       placeholder: ''
     third_party_settings: {  }
   path:

--- a/config/core.entity_form_display.node.objective.default.yml
+++ b/config/core.entity_form_display.node.objective.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.objective.field_goal
     - field.field.node.objective.field_indicators
     - field.field.node.objective.field_objective_type
+    - field.field.node.objective.field_sequence
     - node.type.objective
   module:
     - field_group
@@ -39,6 +40,7 @@ third_party_settings:
       children:
         - field_goal
         - field_objective_type
+        - field_sequence
         - title
         - field_agency
         - field_division
@@ -79,7 +81,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 9
+    weight: 10
     region: content
     settings:
       rows: 5
@@ -95,13 +97,13 @@ content:
     third_party_settings: {  }
   field_agency:
     type: options_select
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   field_division:
     type: options_select
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -139,6 +141,14 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_sequence:
+    type: string_textfield
+    weight: 6
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   path:
     type: path
     weight: 3
@@ -154,7 +164,7 @@ content:
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 6
+    weight: 7
     region: content
     settings:
       size: 60

--- a/config/core.entity_form_display.node.objective.inline.yml
+++ b/config/core.entity_form_display.node.objective.inline.yml
@@ -69,11 +69,10 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_sequence:
-    type: string_textfield
+    type: number
     weight: 1
     region: content
     settings:
-      size: 60
       placeholder: ''
     third_party_settings: {  }
   title:

--- a/config/core.entity_form_display.node.objective.inline.yml
+++ b/config/core.entity_form_display.node.objective.inline.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.objective.field_goal
     - field.field.node.objective.field_indicators
     - field.field.node.objective.field_objective_type
+    - field.field.node.objective.field_sequence
     - node.type.objective
   module:
     - ief_table_view_mode
@@ -23,7 +24,7 @@ mode: inline
 content:
   body:
     type: text_textarea_with_summary
-    weight: 4
+    weight: 5
     region: content
     settings:
       rows: 3
@@ -33,19 +34,19 @@ content:
     third_party_settings: {  }
   field_agency:
     type: options_select
-    weight: 2
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   field_division:
     type: options_select
-    weight: 3
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
   field_indicators:
     type: inline_entity_form_complex_table_view_mode
-    weight: 5
+    weight: 6
     region: content
     settings:
       form_mode: inline
@@ -67,9 +68,17 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  title:
+  field_sequence:
     type: string_textfield
     weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 2
     region: content
     settings:
       size: 60

--- a/config/core.entity_form_display.storage.indicator.default.yml
+++ b/config/core.entity_form_display.storage.indicator.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.storage.indicator.field_notes
     - field.field.storage.indicator.field_objective
     - field.field.storage.indicator.field_plan
+    - field.field.storage.indicator.field_sequence
     - field.field.storage.indicator.field_target
     - storage.storage_type.indicator
   module:
@@ -29,7 +30,7 @@ third_party_settings:
       label: Details
       region: content
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: html_element
       format_settings:
         classes: form--inline
@@ -51,7 +52,7 @@ mode: default
 content:
   field_description:
     type: text_textarea
-    weight: 3
+    weight: 4
     region: content
     settings:
       rows: 5
@@ -81,7 +82,7 @@ content:
     third_party_settings: {  }
   field_measurements:
     type: inline_entity_form_complex_table_view_mode
-    weight: 5
+    weight: 6
     region: content
     settings:
       form_mode: inline
@@ -99,7 +100,7 @@ content:
     third_party_settings: {  }
   field_notes:
     type: text_textarea
-    weight: 6
+    weight: 7
     region: content
     settings:
       rows: 5
@@ -125,6 +126,14 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_sequence:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_target:
     type: options_select
     weight: 8
@@ -132,7 +141,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_administration: true
   name: true
   status: true
   user_id: true
-  field_administration: true

--- a/config/core.entity_form_display.storage.indicator.default.yml
+++ b/config/core.entity_form_display.storage.indicator.default.yml
@@ -127,11 +127,10 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_sequence:
-    type: string_textfield
+    type: number
     weight: 3
     region: content
     settings:
-      size: 60
       placeholder: ''
     third_party_settings: {  }
   field_target:

--- a/config/core.entity_form_display.storage.indicator.inline.yml
+++ b/config/core.entity_form_display.storage.indicator.inline.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.storage.indicator.field_notes
     - field.field.storage.indicator.field_objective
     - field.field.storage.indicator.field_plan
+    - field.field.storage.indicator.field_sequence
     - field.field.storage.indicator.field_target
     - storage.storage_type.indicator
   module:
@@ -81,7 +82,7 @@ content:
     third_party_settings: {  }
   field_measurements:
     type: inline_entity_form_complex_table_view_mode
-    weight: 7
+    weight: 4
     region: content
     settings:
       form_mode: inline
@@ -96,6 +97,14 @@ content:
       collapsed: false
       revision: false
       removed_reference: optional
+    third_party_settings: {  }
+  field_sequence:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_target:
     type: options_select

--- a/config/core.entity_form_display.storage.indicator.inline.yml
+++ b/config/core.entity_form_display.storage.indicator.inline.yml
@@ -98,14 +98,6 @@ content:
       revision: false
       removed_reference: optional
     third_party_settings: {  }
-  field_sequence:
-    type: string_textfield
-    weight: 0
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
   field_target:
     type: options_select
     weight: 6
@@ -117,6 +109,7 @@ hidden:
   field_notes: true
   field_objective: true
   field_plan: true
+  field_sequence: true
   name: true
   status: true
   user_id: true

--- a/config/core.entity_view_display.node.goal.card.yml
+++ b/config/core.entity_view_display.node.goal.card.yml
@@ -5,11 +5,13 @@ dependencies:
   config:
     - core.entity_view_mode.node.card
     - field.field.node.goal.body
+    - field.field.node.goal.field_administration
     - field.field.node.goal.field_goal_type
     - field.field.node.goal.field_image
     - field.field.node.goal.field_objectives
     - field.field.node.goal.field_period
     - field.field.node.goal.field_plan
+    - field.field.node.goal.field_sequence
     - field.field.node.goal.field_topics
     - image.style.1x1_third
     - node.type.goal
@@ -34,10 +36,12 @@ content:
     region: content
 hidden:
   body: true
+  field_administration: true
   field_goal_type: true
   field_objectives: true
   field_period: true
   field_plan: true
+  field_sequence: true
   field_topics: true
   links: true
   search_api_excerpt: true

--- a/config/core.entity_view_display.node.goal.default.yml
+++ b/config/core.entity_view_display.node.goal.default.yml
@@ -74,12 +74,15 @@ content:
     weight: 3
     region: content
   field_sequence:
-    type: string
+    type: number_decimal
     label: above
     settings:
-      link_to_entity: false
+      thousand_separator: ''
+      decimal_separator: .
+      scale: 2
+      prefix_suffix: true
     third_party_settings: {  }
-    weight: 7
+    weight: 1
     region: content
   field_topics:
     type: entity_reference_label

--- a/config/core.entity_view_display.node.goal.default.yml
+++ b/config/core.entity_view_display.node.goal.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.goal.field_objectives
     - field.field.node.goal.field_period
     - field.field.node.goal.field_plan
+    - field.field.node.goal.field_sequence
     - field.field.node.goal.field_topics
     - image.style.1x1_third
     - node.type.goal
@@ -71,6 +72,14 @@ content:
       link: true
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_sequence:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 7
     region: content
   field_topics:
     type: entity_reference_label

--- a/config/core.entity_view_display.node.goal.full.yml
+++ b/config/core.entity_view_display.node.goal.full.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.goal.field_objectives
     - field.field.node.goal.field_period
     - field.field.node.goal.field_plan
+    - field.field.node.goal.field_sequence
     - field.field.node.goal.field_topics
     - node.type.goal
   module:
@@ -70,5 +71,6 @@ content:
 hidden:
   field_administration: true
   field_plan: true
+  field_sequence: true
   field_topics: true
   search_api_excerpt: true

--- a/config/core.entity_view_display.node.goal.ief_table.yml
+++ b/config/core.entity_view_display.node.goal.ief_table.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.goal.field_objectives
     - field.field.node.goal.field_period
     - field.field.node.goal.field_plan
+    - field.field.node.goal.field_sequence
     - field.field.node.goal.field_topics
     - node.type.goal
   module:
@@ -50,6 +51,7 @@ hidden:
   field_image: true
   field_objectives: true
   field_plan: true
+  field_sequence: true
   field_topics: true
   label: true
   links: true

--- a/config/core.entity_view_display.node.objective.card.yml
+++ b/config/core.entity_view_display.node.objective.card.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.objective.field_goal
     - field.field.node.objective.field_indicators
     - field.field.node.objective.field_objective_type
+    - field.field.node.objective.field_sequence
     - node.type.objective
   module:
     - user
@@ -39,4 +40,5 @@ hidden:
   field_goal: true
   field_indicators: true
   field_objective_type: true
+  field_sequence: true
   search_api_excerpt: true

--- a/config/core.entity_view_display.node.objective.default.yml
+++ b/config/core.entity_view_display.node.objective.default.yml
@@ -20,12 +20,15 @@ bundle: objective
 mode: default
 content:
   field_sequence:
-    type: string
+    type: number_decimal
     label: above
     settings:
-      link_to_entity: false
+      thousand_separator: ''
+      decimal_separator: .
+      scale: 2
+      prefix_suffix: true
     third_party_settings: {  }
-    weight: 7
+    weight: 1
     region: content
 hidden:
   body: true

--- a/config/core.entity_view_display.node.objective.default.yml
+++ b/config/core.entity_view_display.node.objective.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.objective.field_goal
     - field.field.node.objective.field_indicators
     - field.field.node.objective.field_objective_type
+    - field.field.node.objective.field_sequence
     - node.type.objective
   module:
     - user
@@ -17,7 +18,15 @@ id: node.objective.default
 targetEntityType: node
 bundle: objective
 mode: default
-content: {  }
+content:
+  field_sequence:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 7
+    region: content
 hidden:
   body: true
   field_administration: true

--- a/config/core.entity_view_display.node.objective.full.yml
+++ b/config/core.entity_view_display.node.objective.full.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.objective.field_goal
     - field.field.node.objective.field_indicators
     - field.field.node.objective.field_objective_type
+    - field.field.node.objective.field_sequence
     - node.type.objective
   module:
     - user
@@ -49,5 +50,6 @@ hidden:
   field_administration: true
   field_goal: true
   field_objective_type: true
+  field_sequence: true
   links: true
   search_api_excerpt: true

--- a/config/core.entity_view_display.node.objective.ief_table.yml
+++ b/config/core.entity_view_display.node.objective.ief_table.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.objective.field_goal
     - field.field.node.objective.field_indicators
     - field.field.node.objective.field_objective_type
+    - field.field.node.objective.field_sequence
     - node.type.objective
   module:
     - options
@@ -39,6 +40,7 @@ hidden:
   field_division: true
   field_goal: true
   field_indicators: true
+  field_sequence: true
   links: true
   search_api_excerpt: true
   status: true

--- a/config/core.entity_view_display.storage.indicator.default.yml
+++ b/config/core.entity_view_display.storage.indicator.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.storage.indicator.field_notes
     - field.field.storage.indicator.field_objective
     - field.field.storage.indicator.field_plan
+    - field.field.storage.indicator.field_sequence
     - field.field.storage.indicator.field_target
     - storage.storage_type.indicator
   module:
@@ -51,6 +52,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_sequence:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 5
     region: content
 hidden:
   field_dimension: true

--- a/config/core.entity_view_display.storage.indicator.default.yml
+++ b/config/core.entity_view_display.storage.indicator.default.yml
@@ -54,10 +54,13 @@ content:
     weight: 3
     region: content
   field_sequence:
-    type: string
+    type: number_decimal
     label: above
     settings:
-      link_to_entity: false
+      thousand_separator: ''
+      decimal_separator: .
+      scale: 2
+      prefix_suffix: true
     third_party_settings: {  }
     weight: 5
     region: content

--- a/config/core.entity_view_display.storage.indicator.ief_table.yml
+++ b/config/core.entity_view_display.storage.indicator.ief_table.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.storage.indicator.field_notes
     - field.field.storage.indicator.field_objective
     - field.field.storage.indicator.field_plan
+    - field.field.storage.indicator.field_sequence
     - field.field.storage.indicator.field_target
     - storage.storage_type.indicator
   module:
@@ -38,6 +39,7 @@ hidden:
   field_notes: true
   field_objective: true
   field_plan: true
+  field_sequence: true
   field_target: true
   label: true
   name: true

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -68,6 +68,7 @@ module:
   path_alias: 0
   pgov_indicator: 0
   pgov_migrate: 0
+  pgov_plan: 0
   rest: 0
   search: 0
   search_api: 0

--- a/config/field.field.node.goal.field_sequence.yml
+++ b/config/field.field.node.goal.field_sequence.yml
@@ -1,0 +1,19 @@
+uuid: 8712c010-e5f4-48d0-bc42-699ff5522de3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_sequence
+    - node.type.goal
+id: node.goal.field_sequence
+field_name: field_sequence
+entity_type: node
+bundle: goal
+label: Sequence
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.node.goal.field_sequence.yml
+++ b/config/field.field.node.goal.field_sequence.yml
@@ -1,4 +1,4 @@
-uuid: 8712c010-e5f4-48d0-bc42-699ff5522de3
+uuid: cc59d3ae-04d2-459c-9bc6-1d0474170978
 langcode: en
 status: true
 dependencies:
@@ -15,5 +15,9 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
-field_type: string
+settings:
+  min: 0.0
+  max: 100.0
+  prefix: ''
+  suffix: ''
+field_type: decimal

--- a/config/field.field.node.objective.field_sequence.yml
+++ b/config/field.field.node.objective.field_sequence.yml
@@ -1,4 +1,4 @@
-uuid: 940ed934-4783-48d8-88d3-76e32c2c1708
+uuid: c83ab66e-7160-424c-9144-7b367a48e448
 langcode: en
 status: true
 dependencies:
@@ -15,5 +15,9 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
-field_type: string
+settings:
+  min: 0.0
+  max: 100.0
+  prefix: ''
+  suffix: ''
+field_type: decimal

--- a/config/field.field.node.objective.field_sequence.yml
+++ b/config/field.field.node.objective.field_sequence.yml
@@ -1,0 +1,19 @@
+uuid: 940ed934-4783-48d8-88d3-76e32c2c1708
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_sequence
+    - node.type.objective
+id: node.objective.field_sequence
+field_name: field_sequence
+entity_type: node
+bundle: objective
+label: Sequence
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.storage.indicator.field_sequence.yml
+++ b/config/field.field.storage.indicator.field_sequence.yml
@@ -1,4 +1,4 @@
-uuid: 17b38202-1f6c-4696-a6be-f3d3224cf98c
+uuid: 8e746106-0ac7-4fa2-b6a5-c8ee8558d39f
 langcode: en
 status: true
 dependencies:
@@ -15,5 +15,9 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
-field_type: string
+settings:
+  min: 0.0
+  max: 100.0
+  prefix: ''
+  suffix: ''
+field_type: decimal

--- a/config/field.field.storage.indicator.field_sequence.yml
+++ b/config/field.field.storage.indicator.field_sequence.yml
@@ -1,0 +1,19 @@
+uuid: 17b38202-1f6c-4696-a6be-f3d3224cf98c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.storage.field_sequence
+    - storage.storage_type.indicator
+id: storage.indicator.field_sequence
+field_name: field_sequence
+entity_type: storage
+bundle: indicator
+label: Sequence
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.storage.node.field_sequence.yml
+++ b/config/field.storage.node.field_sequence.yml
@@ -1,0 +1,21 @@
+uuid: ed8625e6-8760-44a7-a074-115d8bfc5f4d
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_sequence
+field_name: field_sequence
+entity_type: node
+type: string
+settings:
+  max_length: 10
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_sequence.yml
+++ b/config/field.storage.node.field_sequence.yml
@@ -1,4 +1,4 @@
-uuid: ed8625e6-8760-44a7-a074-115d8bfc5f4d
+uuid: d88eda91-8dd7-40e2-88f2-af27353a2156
 langcode: en
 status: true
 dependencies:
@@ -7,11 +7,10 @@ dependencies:
 id: node.field_sequence
 field_name: field_sequence
 entity_type: node
-type: string
+type: decimal
 settings:
-  max_length: 10
-  case_sensitive: false
-  is_ascii: false
+  precision: 10
+  scale: 1
 module: core
 locked: false
 cardinality: 1

--- a/config/field.storage.storage.field_sequence.yml
+++ b/config/field.storage.storage.field_sequence.yml
@@ -1,4 +1,4 @@
-uuid: 63c242f1-d51a-4e87-8190-b0c8d6441ada
+uuid: 8a470ab5-3cee-48a9-864a-685e4a16fd9f
 langcode: en
 status: true
 dependencies:
@@ -7,11 +7,10 @@ dependencies:
 id: storage.field_sequence
 field_name: field_sequence
 entity_type: storage
-type: string
+type: decimal
 settings:
-  max_length: 10
-  case_sensitive: false
-  is_ascii: false
+  precision: 10
+  scale: 1
 module: core
 locked: false
 cardinality: 1

--- a/config/field.storage.storage.field_sequence.yml
+++ b/config/field.storage.storage.field_sequence.yml
@@ -1,0 +1,21 @@
+uuid: 63c242f1-d51a-4e87-8190-b0c8d6441ada
+langcode: en
+status: true
+dependencies:
+  module:
+    - storage
+id: storage.field_sequence
+field_name: field_sequence
+entity_type: storage
+type: string
+settings:
+  max_length: 10
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/migrate_plus.migration.goals.yml
+++ b/config/migrate_plus.migration.goals.yml
@@ -27,6 +27,7 @@ process:
     callable: trim
     source: Name
   uid: constants/uid
+  field_sequence: SequenceIndicator
   body/value: Description
   body/format: constants/body_format
   field_goal_type:

--- a/config/migrate_plus.migration.indicators.yml
+++ b/config/migrate_plus.migration.indicators.yml
@@ -23,6 +23,7 @@ process:
   field_description/format: constants/body_format
   field_notes/value: OtherInformation
   field_notes/format: constants/body_format
+  field_sequence: SequenceIndicator
   field_agency:
     plugin: migration_lookup
     migration: agencies

--- a/config/migrate_plus.migration.objectives.yml
+++ b/config/migrate_plus.migration.objectives.yml
@@ -25,6 +25,7 @@ process:
   uid: constants/uid
   body/value: Description
   body/format: constants/body_format
+  field_sequence: SequenceIndicator
   field_goal:
     plugin: migration_lookup
     migration: goals

--- a/web/modules/custom/pgov_migrate/migrations/migrate_plus.migration.goals.yml
+++ b/web/modules/custom/pgov_migrate/migrations/migrate_plus.migration.goals.yml
@@ -25,6 +25,7 @@ process:
     callable: trim
     source: Name
   uid: constants/uid
+  field_sequence: SequenceIndicator
   body/value: Description
   body/format: constants/body_format
   field_goal_type:

--- a/web/modules/custom/pgov_migrate/migrations/migrate_plus.migration.indicators.yml
+++ b/web/modules/custom/pgov_migrate/migrations/migrate_plus.migration.indicators.yml
@@ -18,6 +18,7 @@ process:
   field_description/format: constants/body_format
   field_notes/value: OtherInformation
   field_notes/format: constants/body_format
+  field_sequence: SequenceIndicator
   field_agency:
     plugin: migration_lookup
     migration: agencies

--- a/web/modules/custom/pgov_migrate/migrations/migrate_plus.migration.objectives.yml
+++ b/web/modules/custom/pgov_migrate/migrations/migrate_plus.migration.objectives.yml
@@ -25,6 +25,7 @@ process:
   uid: constants/uid
   body/value: Description
   body/format: constants/body_format
+  field_sequence: SequenceIndicator
   field_goal:
     plugin: migration_lookup
     migration: goals

--- a/web/modules/custom/pgov_plan/pgov_plan.module
+++ b/web/modules/custom/pgov_plan/pgov_plan.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
 
 /**
  * Implements hook_ENTITY_presave().
@@ -19,7 +20,7 @@ use Drupal\Core\Entity\EntityInterface;
  * the nearest item.
  */
 function pgov_plan_entity_presave(EntityInterface $entity) {
-  if ($entity->hasField('field_administration') && $entity->get('field_administration')->isEmpty()) {
+  if ($entity instanceof FieldableEntityInterface && $entity->hasField('field_administration') && $entity->get('field_administration')->isEmpty()) {
     if ($administration = \Drupal::service('pgov_plan_hierarchy')->getNearestParentEntity($entity, 'administration')) {
       $entity->set('field_administration', ['target_id' => $administration->id()]);
     }

--- a/web/modules/custom/pgov_plan/pgov_plan.module
+++ b/web/modules/custom/pgov_plan/pgov_plan.module
@@ -26,3 +26,50 @@ function pgov_plan_entity_presave(EntityInterface $entity) {
     }
   }
 }
+
+/**
+ * Implements hook_ENTITY_TYPE_load().
+ *
+ * Inspects parent entities and orders their reference fields by the sequence
+ * number of the child items.
+ *
+ * @todo refactor based on similarity to pgov_indicator_sort
+ */
+function pgov_plan_node_load(array $entities): void {
+  $parent_bundles = ['plan', 'goal', 'objective'];
+  $child_fields = ['field_goals', 'field_objectives', 'field_indicators'];
+
+  foreach ($entities as $entity) {
+
+    if (in_array($entity->bundle(), $parent_bundles)) {
+      foreach ($child_fields as $child_field) {
+        if ($entity->hasField($child_field)) {
+          $field = $entity->get($child_field);
+          $values_original = $field->getValue();
+          if ($values = $field->referencedEntities()) {
+            // Sort the current value.
+            usort($values, '_pgov_plan_sequence_sort');
+
+            // Re-set field values if the new deltas are in a different sequence.
+            foreach ($values as $delta => $value) {
+              if ($values_original[$delta]['target_id'] != $value->id()) {
+                $field->set($delta, $value);
+              }
+            }
+            // Nothing more to do after we've processed a field.
+            return;
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * A callback for usort() that orders entities by the value of field_sequence.
+ */
+function _pgov_plan_sequence_sort($entity1, $entity2): int {
+  $seq1 = $entity1->get('field_sequence')?->first()?->getValue()['value'];
+  $seq2 = $entity2->get('field_sequence')?->first()?->getValue()['value'];
+  return ($seq1 > $seq2) ? 1 : 0;
+}


### PR DESCRIPTION
This PR Adds a 'Sequence' field (`field_sequence` ) and populates it from the migration.  On an entity load hook for parent items (Plans, Goals, Objectives), the child items in `field_goals`, `field_objectives` and `field_indicators` are ordered according to sequence, respecting the order that has been entered into Airtable.

The sequence field can also be used in views as a sort condition.