### PR TITLE
WIP: Include front end in ddev configuration

### DIFF
--- a/.ddev/.env.pgov-example
+++ b/.ddev/.env.pgov-example
@@ -8,10 +8,10 @@
 AIRTABLE_API_KEY=""
 
 # See https://next-drupal.org/docs/environment-variables
-NEXT_PUBLIC_DRUPAL_BASE_URL=http://performance.ddev.site
+NEXT_PUBLIC_DRUPAL_BASE_URL=https://performance.ddev.site
 NEXT_IMAGE_DOMAIN=performance.ddev.site
 
-# Authentication
+# Authentication for the NextJS App
 DRUPAL_CLIENT_ID=
 DRUPAL_CLIENT_SECRET=
 

--- a/.ddev/.env.pgov-example
+++ b/.ddev/.env.pgov-example
@@ -6,3 +6,12 @@
 #      data.records:read
 #      schema.bases:read
 AIRTABLE_API_KEY=""
+
+# See https://next-drupal.org/docs/environment-variables
+NEXT_PUBLIC_DRUPAL_BASE_URL=http://performance.ddev.site
+NEXT_IMAGE_DOMAIN=performance.ddev.site
+
+# Authentication
+DRUPAL_CLIENT_ID=
+DRUPAL_CLIENT_SECRET=
+

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -25,11 +25,15 @@ web_extra_exposed_ports:
     http_port: 4001
 web_extra_daemons:
   - name: "frontend"
-    command: "npm install && npm run dev -H 0.0.0.0 -p 3000"
+    command: "npm install && npm run dev -- -H 0.0.0.0 -p 3000"
     directory: /var/www/html/src/frontend
   - name: "docs"
     command: "npm install && npm run start -- -h 0.0.0.0 -p 4000"
     directory: /var/www/html/docs
+hooks:
+  # Ensure the .env file is present.
+  pre-start:
+    - exec-host: "ls .ddev/.env || (cd .ddev && cp .env.pgov-example .env)"
 
 # Key features of DDEV's config.yaml:
 

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -15,11 +15,18 @@ web_environment:
   - DRUSH_ALLOW_XDEBUG=1
 corepack_enable: false
 web_extra_exposed_ports:
+  - name: "Next.js Front End"
+    container_port: 3000
+    https_port: 3000
+    http_port: 3001
   - name: "Documentation"
     container_port: 4000
     https_port: 4000
     http_port: 4001
 web_extra_daemons:
+  - name: "frontend"
+    command: "npm install && npm run dev -H 0.0.0.0 -p 3000"
+    directory: /var/www/html/src/frontend
   - name: "docs"
     command: "npm install && npm run start -- -h 0.0.0.0 -p 4000"
     directory: /var/www/html/docs

--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -1,8 +1,0 @@
-# See https://next-drupal.org/docs/environment-variables
-NEXT_PUBLIC_DRUPAL_BASE_URL=http://performance.ddev.site
-NEXT_IMAGE_DOMAIN=performance.ddev.site
-
-# Authentication
-DRUPAL_CLIENT_ID=
-DRUPAL_CLIENT_SECRET=
-


### PR DESCRIPTION
A few of us are having some issues setting up locals, and this PR is an aim to get everything under one roof by using ddev to launch the front end.

**TODO / SUPPORT NEEDED**

* I am not able to get past the basic auth requirements for the front end site using the user/pass we'd been sharing. What am I missing??
* Testing beyond that blocker :}


**Goals:**

* Make it consistent:  the currently documented process suggests running `npm run` on DDEV's _host_ system, which necessitates having node/npm on the host system, and introduces the possibility of running the front end with a different version or configuration than that of the app itself. 
* Make it repeatable: ultimately, it should be possible for anyone with code access to just run `ddev start` and get a configured, working site.
* Get SSL, domain name for free. DDEV furnishes a `performance.ddev.site` domain and runs each service, with SSL, on a different port. Removing the complexity of communicating between http://localhost:3000 and https://performance.ddev.site/ will probably help with CORS, etc.
* Consolidate logic and documentation. There were two places to set environment variables. This PR advocates for putting all development-related environment variables in .ddev/.env , where they are consolidated, documented, and automatically applied to the environment

**Testing:**
* Back up env files: 
  * rename .ddev/.env to .env-save
  * rename src/frontend/.env to src/frontend/.env
* Stop running the front end site (  so that it's not listening on localhost:3000 )
* Run `ddev restart`

* You should be able to see a 'Next.js front end' service running when you run `ddev describe`
* You should be able to access the front end site at https://performance.ddev.site:3000