### PR TITLE
New goal page design

### DIFF
--- a/config/core.entity_view_display.storage.indicator.default.yml
+++ b/config/core.entity_view_display.storage.indicator.default.yml
@@ -36,11 +36,6 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
-  measurements:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
-    region: content
   field_sequence:
     type: number_decimal
     label: above
@@ -52,7 +47,13 @@ content:
     third_party_settings: {  }
     weight: 5
     region: content
+  measurements:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
 hidden:
+  data: true
   field_administration: true
   field_dimension: true
   field_divisions: true

--- a/config/core.entity_view_display.storage.indicator.ief_table.yml
+++ b/config/core.entity_view_display.storage.indicator.ief_table.yml
@@ -31,6 +31,7 @@ content:
     weight: 1
     region: content
 hidden:
+  data: true
   field_administration: true
   field_dimension: true
   field_divisions: true

--- a/config/graphql_compose.settings.yml
+++ b/config/graphql_compose.settings.yml
@@ -8,9 +8,9 @@ entity_config:
       edges_enabled: true
       routes_enabled: true
   image_style:
-    1x1_third:
-      enabled: false
     media_library:
+      enabled: true
+    third_1x1:
       enabled: true
     thumbnail:
       enabled: true
@@ -83,13 +83,16 @@ entity_config:
       routes_enabled: true
   storage:
     administration:
-      enabled: false
+      enabled: true
     indicator:
       enabled: true
     measurement:
       enabled: true
     period:
       enabled: true
+      query_load_enabled: true
+      edges_enabled: true
+      routes_enabled: true
     person:
       enabled: false
   taxonomy_term:
@@ -134,6 +137,8 @@ field_config:
       body:
         enabled: true
       field_goal_type:
+        enabled: true
+      field_image:
         enabled: true
       field_objectives:
         enabled: true
@@ -189,6 +194,13 @@ field_config:
       field_plan:
         enabled: true
   storage:
+    administration:
+      field_date_range:
+        enabled: true
+      field_president:
+        enabled: true
+      field_vice_president:
+        enabled: true
     indicator:
       field_description:
         enabled: true

--- a/config/image.style.third_1x1.yml
+++ b/config/image.style.third_1x1.yml
@@ -2,7 +2,7 @@ uuid: 43fbc9e6-162c-4106-a653-c7638f98201a
 langcode: en
 status: true
 dependencies: {  }
-name: 1x1_third
+name: third_1x1
 label: '1:1 Third'
 effects:
   4debbc29-d84f-42df-9627-6f0e3415d1f4:

--- a/config/user.role.next_js_site.yml
+++ b/config/user.role.next_js_site.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - storage.storage_type.administration
     - storage.storage_type.indicator
     - storage.storage_type.measurement
     - storage.storage_type.period
@@ -25,6 +26,7 @@ permissions:
   - 'issue subrequests'
   - 'use graphql_compose_server graphql explorer'
   - 'use graphql_compose_server graphql voyager'
+  - 'view published administration storage entities'
   - 'view published indicator storage entities'
   - 'view published measurement storage entities'
   - 'view published period storage entities'

--- a/src/frontend/components/field--objectives.tsx
+++ b/src/frontend/components/field--objectives.tsx
@@ -1,4 +1,4 @@
-import { formatDate } from "lib/utils";
+import ObjectiveIndicator from "./objective-indicator";
 
 interface FieldPeriodProps {
   dateRange: {
@@ -43,49 +43,27 @@ interface FieldObjectiveProps {
 export function FieldObjectives({fieldObjectives} : FieldObjectiveProps) {
   return (
     <div>
-      <h2 className="font-sans-2xl margin-bottom-1" id="objectives">
-        Objectives
-      </h2>
       <ol className="add-list-reset">
         {fieldObjectives?.map((objective, index) => (
-          <li key={objective.id} className={`${index > 0 ? "border-top" : ""}`}>
-            <h3 id={objective.id}>{objective.title}</h3>
-            <h4 className="margin-bottom-0">Performance indicators</h4>
+          <li key={objective.id} className={``}>
+            <h2 id={objective.id}>Objective {index + 1}: {objective.title}</h2>
             {objective.indicators?.length > 0 && (
               <ol className="add-list-reset">
-                {objective.indicators?.map((indicator) => (
-                  <li key={indicator.id}>
-                    <p>{indicator.name}</p>
-                    {(indicator.measurements && indicator.measurements.length > 0) && (
-                      <table className="usa-table usa-table--stacked width-full">
-                        <caption className="usa-sr-only">
-                          Date and result measurements for the {indicator.name} performance indicator.
-                        </caption>
-                        <thead>
-                          <tr>
-                            <th>Start date</th>
-                            <th>End date</th>
-                            <th>Actual result</th>
-                            <th>Target result</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {indicator.measurements?.map((measurement) => (
-                            <tr key={measurement.id}>
-                              <td>{formatDate(measurement.period?.dateRange?.start.time)}</td>
-                              <td>{formatDate(measurement.period?.dateRange?.end.time)}</td>
-                              <td>{measurement.value ? measurement.value : "N/A"}</td>
-                              <td>{measurement.targetValue ? measurement.targetValue : "N/A"}</td>
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
-                    )}
-                    {indicator.notes?.processed && (
-                      <div dangerouslySetInnerHTML={{ __html: indicator.notes?.processed }} />
-                    )}
-                  </li>
-                ))}
+                {objective.indicators?.map((indicator, indicatorIndex) => {
+                  let listBorders = "border-top";
+                  let linkBorders = ""
+                  if (indicatorIndex === 0) {
+                    listBorders = "radius-top-lg";
+                    linkBorders = "radius-top-lg";
+                  } else if (indicatorIndex === objective.indicators.length - 1) {
+                    listBorders = "radius-bottom-lg border-top";
+                  }
+                  return (
+                    <li key={indicator.id} className={`bg-white ${listBorders}`}>
+                      <ObjectiveIndicator indicator={indicator} borders={linkBorders}/>
+                    </li>
+                  )
+                })}
               </ol>
             )}
           </li>
@@ -94,3 +72,13 @@ export function FieldObjectives({fieldObjectives} : FieldObjectiveProps) {
     </div>
   );
 }
+
+                  // return(
+                  //   <li key={goal.id} >
+                  //     <Link
+                  //       className={`grid-row flex-no-wrap flex-justify text-no-underline font-sans-md padding-2 text-base-darkest ${linkBorders}`}
+                  //       href={goal.path.alias}>
+                  //         <span>{goal.title}</span>
+                  //         <Icon.NavigateNext size={3} aria-hidden={true} />
+                  //     </Link>
+                  //   </li>

--- a/src/frontend/components/goal-totals.tsx
+++ b/src/frontend/components/goal-totals.tsx
@@ -7,11 +7,15 @@ interface GoalsTotalsProps {
 const GoalsTotals = ({goals, objectives, indicators}: GoalsTotalsProps) => {
   return (
     <div>
-      <ul className="font-sans-3xs grid-row add-list-reset flex-justify text-bold">
-        <li>
-          <span className="font-sans-lg display-block">{goals}</span> Goals
-        </li>
-        <li>
+      <ul className="font-sans-3xs grid-row add-list-reset text-bold">
+        {goals > 0
+          && (
+            <li className="margin-right-3">
+              <span className="font-sans-lg display-block">{goals}</span> Goals
+            </li>
+          )
+        }
+        <li className="margin-right-3">
           <span className="font-sans-lg display-block">{objectives}</span> Objectives
         </li>
         <li>

--- a/src/frontend/components/node--goal.tsx
+++ b/src/frontend/components/node--goal.tsx
@@ -1,93 +1,136 @@
 import { useRef } from 'react';
 import Link from 'next/link'
+import Image from "next/image";
 import { DrupalNode } from "next-drupal";
+import { Icon, Button, ButtonGroup } from "@trussworks/react-uswds";
 import { USAInPageNav } from "./usa--in-page-nav";
 import { FieldGoalType } from "./field--goal-type";
 import { USABreadcrumb } from './usa--breadcrumb';
 import { FieldObjectives } from './field--objectives';
 import AgencyInfoBox from './agency-info-box';
-import { FieldPeriod } from './field--period';
+import { FieldLogo } from "./field--logo";
+import GoalsTotals from "./goal-totals";
 
 interface NodeGoalProps {
   node: DrupalNode;
   storageData: any;
 }
 
+function calculateObjectiveIndicatorTotals(objectives) {
+  let objectiveCount = 0;
+  let indicatorCount = 0;
+  if (objectives) {
+    objectiveCount += objectives.length;
+    objectives.forEach((objective) => {
+      const indicators = objective.indicators;
+      if (indicators) {
+        indicatorCount += indicators.length;
+      }
+    })
+  }
+  return {
+    objectives: objectiveCount,
+    indicators: indicatorCount,
+  }
+}
+
+function objectiveAverageValue(indicators) {
+  const count = indicators.length;
+  let total = 0
+  indicators.forEach((indicator) => {
+    total += indicator.progress;
+  })
+  return total / count;
+}
+
 export function NodeGoal({ node, storageData, ...props }: NodeGoalProps) {
   let mainContentRef = useRef();
   const { title, field_topics, field_goal_type, field_plan } = node;
   const { field_agency } = field_plan;
-  let goalTypeString = field_goal_type;
-  if (field_goal_type == "apg") {
-    goalTypeString = "priority";
-  }
+  const totals = calculateObjectiveIndicatorTotals(storageData.objectives);
+
+  const startDate = new Date(storageData.plan?.administration?.dateRange?.start.time);
+  const endDate = new Date(storageData.plan?.administration?.dateRange?.end.time)
+  const dateOptions: Intl.DateTimeFormatOptions = {year: "numeric"}
+  const { image } = storageData;
+  const imageUrl = image?.mediaImage?.variations[0]?.url;
   const breadcrumbLinks = [
     {label: field_plan.title, href: field_plan.path.alias}
   ];
-<USAInPageNav 
-            logo={field_agency.field_logo ? field_agency.field_logo : null}
-            logoAbove={false}
-            links={buildInPageLinks()}
-          />
-  function buildInPageLinks() {
-    let links = [
-      {href: "#goal-description", label: `About this ${field_agency.field_acronym} ${goalTypeString} goal`, primary: true}
-    ];
-    if (storageData.objectives) {
-      links.push({href: "#objectives", label: `Objectives`, primary: true});
-      storageData.objectives.forEach((objective) => {
-        links.push({href: `#${objective.id}`, label: objective.title, primary: false });
-      })
-
-    }
-    return links;
-  }
   return (
     <>
       <USABreadcrumb activeItem={title} links={breadcrumbLinks} />
-      {/* <div className="">
-        <div className="">
-          <FieldGoalType field_goal_type={field_goal_type} />
-        </div>
-      </div> */}
       <div className="grid-row">
         <div className="side-bar">
-          <div>
-            <FieldGoalType field_goal_type={field_goal_type} />
-            <FieldPeriod field_period={storageData?.period} />
-          </div>
-          {title}
-          <AgencyInfoBox
-            acronym={field_agency.field_acronym}
-            logo={field_agency.field_logo}
-            title={field_agency.title}
+        <span className="text-white radius-pill bg-black padding-x-1 font-sans-3xs">Plan</span>
+        <h1 className="font-sans-xl">{title}</h1>
+        {imageUrl &&
+          <Image
+            src={imageUrl}
+            width={400}
+            height={400}
+            alt={image.mediaImage?.alt ? image.mediaImage.alt : `${title} image`}
+            priority
+            className="flex-align-self-center"
           />
-          {/* <USAInPageNav 
-            logo={field_agency.field_logo ? field_agency.field_logo : null}
-            logoAbove={false}
-            links={buildInPageLinks()}
-          /> */}
+        }
+        <div className="margin-bottom-2 padding-top-1 border-top border-base-lighter">
+          <GoalsTotals
+            goals={0}
+            objectives={totals.objectives}
+            indicators={totals.indicators}
+          />
         </div>
-        <div className="content-area">
-          <h1 className="font-sans-2xl">{title}</h1>
-          <main id="main-content" className="main-content" ref={mainContentRef}>
-            <h2 className="font-sans-xl" id="goal-description">
-              About this {field_agency.field_acronym} {goalTypeString} goal
-            </h2>
-            {node.body?.processed && (
-              <div
-                dangerouslySetInnerHTML={{ __html: node.body?.processed }}
-                className="font-body-md"
-              />
-            )}
-            <p>
-              <span className="font-body-md text-bold">Strategic plan:</span>{" "}
-              <Link href={`${field_agency.path.alias}`}>{field_plan.title}</Link>
-            </p>
-            {storageData?.objectives && (
-              <FieldObjectives fieldObjectives={storageData.objectives} />
-            )}
-            {field_topics.length > 0 && (
+        <div className="margin-bottom-2 border-top border-base-lighter">
+          <h2 className="font-sans-3xs text-semibold margin-bottom-05">Plan</h2>
+          <Link
+            className="text-no-underline"
+            href={field_plan.path.alias}
+          >
+            {field_plan.title}
+          </Link>
+        </div>
+        <div className="grid-row flex-justify flex-no-wrap margin-bottom-2 border-top border-base-lighter">
+          <div className="grid-row flex-column">
+            <h2 className="font-sans-3xs text-semibold margin-bottom-05">Owner</h2>
+            <span className="font-sans-3xs">{field_agency.title}</span>
+          </div>
+          <div className="flex-align-self-center">
+            <FieldLogo
+              field_logo={field_agency.field_logo}
+              height={24}
+              width={24}
+            />
+          </div>
+        </div>
+        {startDate && endDate &&
+          <div className="margin-bottom-2 border-top border-base-lighter">
+            <h2 className="font-sans-3xs text-semibold margin-bottom-05">Duration</h2>
+            <span>Fiscal Year {startDate.toLocaleDateString('en-US', dateOptions)}-{endDate.toLocaleDateString('en-US', dateOptions)}</span>
+          </div>
+          }
+        <div className="margin-bottom-2 border-top border-base-lighter">
+          <h2 className="font-sans-3xs text-semibold margin-bottom-05">Description</h2>
+          <div
+            dangerouslySetInnerHTML={{ __html: node.body?.processed }}
+            className="font-body-sm"
+          />
+        </div>
+        {field_plan?.field_file
+          && (
+            <div className="margin-bottom-2">
+              <Link
+                className="text-no-underline grid-row flex-align-center flex-justify-center border radius-md width-full padding-y-1 padding-x-205"
+                href={field_plan.field_file.field_media_document.uri.url}
+              >
+                <Icon.FilePresent size={3} aria-hidden={true} />
+                <span>View as PDF</span>
+              </Link>
+            </div>
+          )}
+        <div className="margin-bottom-2 border-top border-base-lighter">
+          <h2 className="font-sans-3xs text-semibold margin-bottom-05">Tags</h2>
+          {field_topics.length > 0 && (
               <ul className="add-list-reset grid-row">
                 {field_topics.map((topic) => (
                   <li className="margin-bottom-2 margin-right-2" key={topic.id}>
@@ -96,6 +139,34 @@ export function NodeGoal({ node, storageData, ...props }: NodeGoalProps) {
                 ))}
               </ul>
             )}
+        </div>
+      </div>
+        <div className="content-area">
+          <main id="main-content" className="main-content padding-x-4 padding-bottom-5 padding-top-8" ref={mainContentRef}>
+            <div>
+              <h2 className="font-sans-xl margin-top-0 margin-bottom-1" id="goal-description">
+                Overview
+              </h2>
+              {storageData?.objectives && (
+                <ol className="add-list-reset grid-row flex-no-wrap">
+                  {storageData.objectives.map((objective, index) => (
+                    <li key={objective.id} className="padding-1 radius-lg">
+                     <div className="bg-white padding-2 radius-lg">
+                      <h3 className="margin-top-0">Objective {index + 1}</h3>
+                      <p>{objective.title}</p>
+                      {objective?.indicators && objective?.indicators.length > 0 &&
+                        <progress value={objectiveAverageValue(objective.indicators)} max={100} />
+                      }
+                     </div>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </div>
+            {storageData?.objectives && (
+              <FieldObjectives fieldObjectives={storageData.objectives} />
+            )}
+            
           </main>
         </div>
       </div>

--- a/src/frontend/components/node--plan.tsx
+++ b/src/frontend/components/node--plan.tsx
@@ -36,12 +36,12 @@ function calculateObjectiveIndicatorTotals(goals) {
 
 export function NodePlan({node, storageData, ...props}: NodePlanProps) {
   let mainContentRef = useRef();
-  const { title, field_agency, field_link, field_goals } = node;
+  const { title, field_agency, field_file, field_goals } = node;
   const [listView, setListView] = useState(true);
   const totals = calculateObjectiveIndicatorTotals(field_goals);
   const masonryBP = {350: 1, 750: 2, 1060: 3, 1400: 4};
-  const startDate = new Date(storageData.period.dateRange.start.time);
-  const endDate = new Date(storageData.period.dateRange.end.time)
+  const startDate = new Date(storageData.administration?.dateRange?.start.time);
+  const endDate = new Date(storageData.administration?.dateRange?.end.time)
   const dateOptions: Intl.DateTimeFormatOptions = {year: "numeric"}
   return (
     <>
@@ -50,12 +50,14 @@ export function NodePlan({node, storageData, ...props}: NodePlanProps) {
         <div className="side-bar">
           <span className="text-white radius-pill bg-black padding-x-1 font-sans-3xs">Plan</span>
           <h1 className="font-sans-xl">{title}</h1>
-          <GoalsTotals
-            goals={totals.goals}
-            objectives={totals.objectives}
-            indicators={totals.indicators}
-          />
-          <div className="grid-row flex-justify flex-no-wrap">
+          <div className="margin-bottom-2 padding-top-1 border-top border-base-lighter">
+            <GoalsTotals
+              goals={totals.goals}
+              objectives={totals.objectives}
+              indicators={totals.indicators}
+            />
+          </div>
+          <div className="grid-row flex-justify flex-no-wrap margin-bottom-2 border-top border-base-lighter">
             <div className="grid-row flex-column">
               <h2 className="font-sans-3xs text-semibold margin-bottom-05">Owner</h2>
               <span className="font-sans-3xs">{field_agency.title}</span>
@@ -68,28 +70,39 @@ export function NodePlan({node, storageData, ...props}: NodePlanProps) {
               />
             </div>
           </div>
-          <div>
-            <h2 className="font-sans-3xs text-semibold margin-bottom-05">Duration</h2>
-            <span>Fiscal Year {startDate.toLocaleDateString('en-US', dateOptions)}-{endDate.toLocaleDateString('en-US', dateOptions)}</span>
-          </div>
-          <div>
-            <h2 className="font-sans-3xs text-semibold margin-bottom-05">Description</h2>
-          </div>
-          <div>
-            <Link
-              className="text-no-underline grid-row flex-align-center flex-justify-center border radius-md width-full padding-y-1 padding-x-205"
-              href={`${field_link.uri}`}
-            >
-              <Icon.FilePresent size={3} aria-hidden={true} />
-              <span>View as PDF</span>
-            </Link>
-          </div>
+          {startDate && endDate &&
+            <div className="margin-bottom-2 border-top border-base-lighter">
+              <h2 className="font-sans-3xs text-semibold margin-bottom-05">Duration</h2>
+              <span>Fiscal Year {startDate.toLocaleDateString('en-US', dateOptions)}-{endDate.toLocaleDateString('en-US', dateOptions)}</span>
+            </div>
+          }
+          {node.body &&
+          (
+            <div className="margin-bottom-2 border-top border-base-lighter">
+              <h2 className="font-sans-3xs text-semibold margin-bottom-05">Description</h2>
+              <div
+                dangerouslySetInnerHTML={{ __html: node.body?.processed }}
+                className="font-body-sm"
+              />
+            </div>
+          )}
+          {field_file &&
+            <div>
+              <Link
+                className="text-no-underline grid-row flex-align-center flex-justify-center border radius-md width-full padding-y-1 padding-x-205"
+                href={field_file.field_media_document.uri.url}
+              >
+                <Icon.FilePresent size={3} aria-hidden={true} />
+                <span>View as PDF</span>
+              </Link>
+            </div>
+          }
         </div>
         <div className="content-area">
           
           <main id="main-content" className="main-content padding-x-4 padding-bottom-5 padding-top-8" ref={mainContentRef}>
             <div className="grid-row flex-justify">
-              <h2>Goals</h2>
+              <h2 className="font-sans-xl margin-top-0">Goals</h2>
               <ButtonGroup type="segmented">
                 <Button
                   outline

--- a/src/frontend/components/objective-indicator.tsx
+++ b/src/frontend/components/objective-indicator.tsx
@@ -1,0 +1,92 @@
+import { formatDate } from "lib/utils";
+import { LineChart, Line, CartesianGrid, XAxis, YAxis } from 'recharts';
+import { useState } from "react";
+import { Icon } from "@trussworks/react-uswds";
+
+function buildChartData(names, targetValues, actualValues) {
+  let dataArray = [];
+  if(!names) {
+    return [];
+  }
+  names.forEach((name, index) => {
+    dataArray.push({
+      name: name,
+      Targets: targetValues[index],
+      Actuals: actualValues[index],
+    })
+  })
+  return dataArray
+}
+
+const ObjectiveIndicator = ({indicator, borders}) => {
+  const [open, setOpen] = useState(false)
+  const { name, measurements } = indicator;
+  const data = buildChartData(indicator.names, indicator.targetValues, indicator.values);
+  return(
+    <div className={`objective-indicator text-no-underline font-sans-md text-base-darkest ${borders}`}>
+      <button 
+        onClick={() => setOpen(!open)}
+        className="padding-2 grid-row objective-indicator-button"
+      >
+        <span className="objective-name flex-1">{name}</span>
+        {indicator.progress
+          && (
+            <div className="grid-row margin-right-2">
+              <progress className="margin-right-2" value={indicator.progress} max={100} />
+              <span>{indicator.progress}%</span>
+            </div>
+          )
+        }
+        {open
+        ? <Icon.ExpandLess aria-hidden={true} size={3} />
+        : <Icon.ExpandMore aria-hidden={true} size={3} />
+        }
+      </button>
+      {open &&
+        <div className="grid-row padding-2">
+         <div>
+          {(measurements && measurements.length > 0) && (
+            <table className="usa-table usa-table--stacked width-full">
+              <caption className="usa-sr-only">
+                Date and result measurements for the {name} performance indicator.
+              </caption>
+              <thead>
+                <tr>
+                  <th>Start date</th>
+                  <th>End date</th>  
+                  <th>Actual result</th>
+                  <th>Target result</th>
+                </tr>
+              </thead>
+              <tbody>
+                {measurements?.map((measurement) => (
+                  <tr key={measurement.id}>
+                    <td>{formatDate(measurement.period?.dateRange?.start.time)}</td>
+                    <td>{formatDate(measurement.period?.dateRange?.end.time)}</td>
+                    <td>{measurement.value ? measurement.value : "N/A"}</td>
+                    <td>{measurement.targetValue ? measurement.targetValue : "N/A"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            )}
+          </div>
+          <div>
+            <LineChart width={600} height={300} data={data}>
+              <Line type="monotone" dataKey="Targets" stroke="#162152" />
+              <Line type="monotone" dataKey="Actuals" stroke="#E41B3C" />
+              <CartesianGrid stroke="#ccc" />
+              <XAxis dataKey="name" />
+              <YAxis />
+            </LineChart>
+          </div>
+          {indicator.notes?.processed && (
+            <div dangerouslySetInnerHTML={{ __html: indicator.notes?.processed }} />
+          )}
+        </div>
+      }
+    </div>
+  );
+}
+
+export default ObjectiveIndicator;

--- a/src/frontend/lib/graphqlQueries.ts
+++ b/src/frontend/lib/graphqlQueries.ts
@@ -6,6 +6,19 @@ export const graphqlQueries = {
           entity {
             __typename
             ... on NodeGoal {
+              image {
+                ... on MediaImage {
+                  id
+                  name
+                  mediaImage {
+                    alt
+                    title
+                    variations(styles: THIRD1X1) {
+                      url
+                    }
+                  }
+                }
+              }
               objectives {
                 ... on NodeObjective {
                   id
@@ -14,6 +27,12 @@ export const graphqlQueries = {
                     ... on StorageIndicator {
                       id
                       name
+                      progress
+                      dates
+                      target
+                      targetValues
+                      names
+                      values
                       notes {
                         processed
                       }
@@ -24,32 +43,30 @@ export const graphqlQueries = {
                           targetValue
                           value
                           status
-                          period {
-                            ... on StoragePeriod {
-                              id
-                              name
-                              duration
-                              dateRange {
-                                end {
-                                  time
-                                }
-                                start {
-                                  time
-                                }
-                              }
-                            }
-                          }
+                          
                         }
                       }
                     }
                   }
                 }
               }
-              period {
-                ... on StoragePeriod {
+              plan {
+                ... on NodePlan {
                   id
-                  name
-                  
+                  administration {
+                    ... on StorageAdministration {
+                      id
+                      name
+                      dateRange {
+                        end {
+                          time
+                        }
+                        start {
+                          time
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -64,8 +81,8 @@ export const graphqlQueries = {
           entity {
             __typename
             ... on NodePlan {
-              period {
-                ... on StoragePeriod {
+              administration {
+                ... on StorageAdministration {
                   id
                   name
                   dateRange {

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "^18.2.0",
         "react-intersection-observer": "^9.13.1",
         "react-responsive-masonry": "2.2.0",
+        "recharts": "^2.15.1",
         "sharp": "^0.32.6"
       },
       "devDependencies": {
@@ -40,6 +41,17 @@
       "engines": {
         "node": "22.11.0",
         "npm": "10.9.2"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
+      "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -808,6 +820,60 @@
         "react": "^16.x || ^17.x || ^18.x",
         "react-dom": "^16.x || ^17.x || ^18.x"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -2053,6 +2119,14 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -2137,8 +2211,117 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
       "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2218,6 +2401,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -2338,6 +2526,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/drupal-jsonapi-params": {
@@ -3170,6 +3367,14 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -3779,6 +3984,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-arguments": {
@@ -4538,6 +4751,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5585,6 +5803,35 @@
       "resolved": "https://registry.npmjs.org/react-responsive-masonry/-/react-responsive-masonry-2.2.0.tgz",
       "integrity": "sha512-IYbnfe2tWCZ3pvyTLyBWPj7uv5ZmNOULYMcAZi5a47ZLhSotOck1vkkISq6gP2qiyWdMvPfeMhjvYzUYGw9BOQ=="
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -5625,6 +5872,46 @@
         "object-assign": "^4.1.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.1.tgz",
+      "integrity": "sha512-v8PUTUlyiDe56qUj82w/EDVuzEFXwEHp9/xOowGAZwfLjB9uAy3GllQVIYMWF6nU+qibx85WF75zD7AjqoT54Q==",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
@@ -5646,6 +5933,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.3",
@@ -6553,6 +6845,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6809,6 +7106,27 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8= sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -438,7 +438,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.4.1.tgz",
       "integrity": "sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "detect-libc": "^1.0.3",
@@ -724,7 +724,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "detect-libc": "bin/detect-libc.js"
@@ -737,7 +737,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1780,7 +1780,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -1927,7 +1927,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
       "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -3246,7 +3246,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3712,7 +3712,7 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
       "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -3938,7 +3938,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI= sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3987,7 +3987,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -4026,7 +4026,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -4730,7 +4730,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -5305,7 +5305,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -5442,7 +5442,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -5579,7 +5578,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-responsive-masonry": {
@@ -5605,7 +5603,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
       "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.16.0"
@@ -5865,7 +5863,7 @@
       "version": "1.79.5",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.5.tgz",
       "integrity": "sha512-W1h5kp6bdhqFh2tk3DsI771MoEJjvrSY/2ihJRJS4pjIyfJCw0nTsxqhnrUzaLMOJjFchj8rOvraI/YUVjtx5g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.4.1",
@@ -6559,7 +6557,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -24,6 +24,7 @@
     "react-dom": "^18.2.0",
     "react-intersection-observer": "^9.13.1",
     "react-responsive-masonry": "2.2.0",
+    "recharts": "^2.15.1",
     "sharp": "^0.32.6"
   },
   "devDependencies": {
@@ -44,8 +45,15 @@
   },
   "lint-staged": {
     "!(*.ts|*.tsx|*.js|*.jsx)": "prettier --write --ignore-unknown",
-    "*.{ts, tsx}": ["tsc-files --noEmit --pretty","eslint", "prettier --write"],
-    "*.{js, jsx}": ["eslint", "prettier --write"]
+    "*.{ts, tsx}": [
+      "tsc-files --noEmit --pretty",
+      "eslint",
+      "prettier --write"
+    ],
+    "*.{js, jsx}": [
+      "eslint",
+      "prettier --write"
+    ]
   },
   "engines": {
     "node": "22.11.0",

--- a/src/frontend/pages/[...slug].tsx
+++ b/src/frontend/pages/[...slug].tsx
@@ -71,15 +71,19 @@ export async function getStaticProps(
       // "field_objectives.field_indicators.field_measurements",
       "field_plan",
       "field_plan.field_agency",
+      "field_plan.field_file",
+      "field_plan.field_file.field_media_document",
       "field_plan.field_agency.field_logo",
-      "field_plan.field_agency.field_logo.field_media_image"
+      "field_plan.field_agency.field_logo.field_media_image",
     ]);
-    params.addFields("node--plan", ["field_agency", "title", "path"]);
+    params.addFields("node--plan", ["field_agency", "title", "path", "field_file"]);
     params.addFields("node--objective", ["title", "body", "field_indicators"]);
   } else if (type === "node--plan") {
     params.addInclude([
       "field_period",
       "field_goals",
+      "field_file",
+      "field_file.field_media_document",
       "field_agency",
       "field_agency.field_logo",
       "field_agency.field_logo.field_media_image",

--- a/src/frontend/styles/components/objective-indicator.scss
+++ b/src/frontend/styles/components/objective-indicator.scss
@@ -1,0 +1,8 @@
+.objective-indicator-button {
+  background: none;
+  border: none;
+  min-width: 100%;
+  min-height: 100%;
+  text-align: left;
+  cursor: pointer;
+}

--- a/src/frontend/styles/project-styles.scss
+++ b/src/frontend/styles/project-styles.scss
@@ -2,6 +2,7 @@
 @import "./components/usa--header.scss";
 @import "./components/usa--in-page-nav.scss";
 @import "./components/usa--breadcrumb.scss";
+@import "./components/objective-indicator.scss";
 
 body {
   background-color: #e6e6e6;


### PR DESCRIPTION
This PR updates the design on the goal page and matches the plan side bar to the new goal sidebar.
To test:

1. Pull code
2. Import config
3. in frontend run npm install to get recharts
4. navigate site
5. This was mainly designed to show off the Trump 47 plan and goals

I still need to clean up the cards on the plan view now that we have images.