### PR TITLE
Add indicators and type selection to homepage

### DIFF
--- a/config/facets.facet_source.search_api__views_page__goals__page_1.yml
+++ b/config/facets.facet_source.search_api__views_page__goals__page_1.yml
@@ -1,0 +1,9 @@
+uuid: fcf79d3f-f238-4dd6-9faa-fc2c68fb6b2f
+langcode: en
+status: true
+dependencies: {  }
+id: search_api__views_page__goals__page_1
+name: 'search_api:views_page__goals__page_1'
+filter_key: null
+url_processor: query_string
+breadcrumb: {  }

--- a/config/graphql_compose.settings.yml
+++ b/config/graphql_compose.settings.yml
@@ -86,6 +86,9 @@ entity_config:
       enabled: true
     indicator:
       enabled: true
+      query_load_enabled: true
+      edges_enabled: true
+      routes_enabled: true
     measurement:
       enabled: true
     period:

--- a/config/search_api.index.goals.yml
+++ b/config/search_api.index.goals.yml
@@ -8,12 +8,22 @@ dependencies:
     - search_api.server.database_search
   module:
     - node
+    - storage
     - taxonomy
 id: goals
 name: Goals
 description: ''
 read_only: false
 field_settings:
+  aggregated_administration:
+    label: 'Aggregated administration'
+    property_path: aggregated_field
+    type: string
+    configuration:
+      type: union
+      fields:
+        - 'entity:node/field_administration'
+        - 'entity:storage/field_administration'
   aggregated_field:
     label: 'Aggregated field'
     property_path: aggregated_field
@@ -25,6 +35,15 @@ field_settings:
         - 'entity:node/field_agency'
         - 'entity:node/field_goals'
         - 'entity:node/title'
+  aggregated_type:
+    label: type
+    property_path: aggregated_field
+    type: string
+    configuration:
+      type: union
+      fields:
+        - 'entity:node/type'
+        - 'entity:storage/type'
   field_administration:
     label: Administration
     datasource_id: 'entity:node'
@@ -50,6 +69,14 @@ datasource_settings:
       selected:
         - goal
         - plan
+    languages:
+      default: true
+      selected: {  }
+  'entity:storage':
+    bundles:
+      default: false
+      selected:
+        - indicator
     languages:
       default: true
       selected: {  }

--- a/config/views.view.goals.yml
+++ b/config/views.view.goals.yml
@@ -399,10 +399,10 @@ display:
         options: {  }
       empty: {  }
       sorts:
-        aggregated_field:
-          id: aggregated_field
+        search_api_relevance:
+          id: search_api_relevance
           table: search_api_index_goals
-          field: aggregated_field
+          field: search_api_relevance
           relationship: none
           group_type: group
           admin_label: ''

--- a/config/views.view.goals.yml
+++ b/config/views.view.goals.yml
@@ -684,86 +684,138 @@ display:
                   sort: 50
                 settings:
                   sort: ASC
-        field_administration:
-          id: field_administration
+        facets_aggregated_administration:
+          id: facets_aggregated_administration
           table: search_api_index_goals
-          field: field_administration
+          field: facets_aggregated_administration
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: search_api_numeric
-          operator: '!='
-          value:
-            min: ''
-            max: ''
-            value: '54'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: field_administration_op
-            label: Administration
-            description: null
-            use_operator: false
-            operator: field_administration_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: field_administration
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            min_placeholder: null
-            max_placeholder: null
-            placeholder: null
-          is_grouped: false
-          group_info:
-            label: Administration
-            description: null
-            identifier: field_administration
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items:
-              1: {  }
-              2: {  }
-              3: {  }
-        field_administration_1:
-          id: field_administration_1
-          table: search_api_index_goals
-          field: field_administration
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: search_api_numeric
+          plugin_id: facets_filter
           operator: '='
-          value:
-            min: ''
-            max: ''
-            value: ''
+          value: ''
           group: 1
           exposed: true
           expose:
-            operator_id: field_administration_1_op
-            label: Administration
+            operator_id: ''
+            label: 'Aggregated administration'
             description: ''
             use_operator: false
-            operator: field_administration_1_op
+            operator: ''
             operator_limit_selection: false
             operator_list: {  }
-            identifier: Administration
+            identifier: aggregated_administration
             required: false
             remember: false
-            multiple: false
+            multiple: true
             remember_roles:
               authenticated: authenticated
               anonymous: '0'
               content_editor: '0'
               administrator: '0'
               next_js_site: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          hierarchy: false
+          label_display: visible
+          facet:
+            query_operator: or
+            min_count: 1
+            show_numbers: false
+            processor_configs: {  }
+        facets_aggregated_type:
+          id: facets_aggregated_type
+          table: search_api_index_goals
+          field: facets_aggregated_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: facets_filter
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: type
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: aggregated_type
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_editor: '0'
+              administrator: '0'
+              next_js_site: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          hierarchy: false
+          label_display: visible
+          facet:
+            query_operator: or
+            min_count: 1
+            show_numbers: true
+            processor_configs:
+              raw_value_widget_order:
+                weights:
+                  sort: 50
+                settings:
+                  sort: ASC
+        aggregated_administration:
+          id: aggregated_administration
+          table: search_api_index_goals
+          field: aggregated_administration
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_string
+          operator: '!='
+          value:
+            min: ''
+            max: ''
+            value: '46'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
             min_placeholder: ''
             max_placeholder: ''
             placeholder: ''
@@ -808,6 +860,221 @@ display:
     display_plugin: page
     position: 1
     display_options:
+      filters:
+        aggregated_field:
+          id: aggregated_field
+          table: search_api_index_goals
+          field: aggregated_field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_string
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: aggregated_field_op
+            label: 'Aggregated field'
+            description: ''
+            use_operator: false
+            operator: aggregated_field_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: aggregated_field
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_editor: '0'
+              administrator: '0'
+              next_js_site: '0'
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: 'Aggregated field'
+            description: null
+            identifier: aggregated_field
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1: {  }
+              2: {  }
+              3: {  }
+        facets_name:
+          id: facets_name
+          table: search_api_index_goals
+          field: facets_name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: facets_filter
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Topics » Taxonomy term » Name'
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: Topics
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_editor: '0'
+              administrator: '0'
+              next_js_site: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          hierarchy: false
+          label_display: visible
+          facet:
+            query_operator: or
+            min_count: 1
+            show_numbers: true
+            processor_configs:
+              combine_processor:
+                weights:
+                  build: 5
+                settings: {  }
+              raw_value_widget_order:
+                weights:
+                  sort: 50
+                settings:
+                  sort: ASC
+        facets_aggregated_type:
+          id: facets_aggregated_type
+          table: search_api_index_goals
+          field: facets_aggregated_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: facets_filter
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: type
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: aggregated_type
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_editor: '0'
+              administrator: '0'
+              next_js_site: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          hierarchy: false
+          label_display: visible
+          facet:
+            query_operator: or
+            min_count: 1
+            show_numbers: false
+            processor_configs: {  }
+        facets_aggregated_administration:
+          id: facets_aggregated_administration
+          table: search_api_index_goals
+          field: facets_aggregated_administration
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: facets_filter
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Aggregated administration'
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: aggregated_administration
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_editor: '0'
+              administrator: '0'
+              next_js_site: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          hierarchy: false
+          label_display: visible
+          facet:
+            query_operator: or
+            min_count: 1
+            show_numbers: false
+            processor_configs: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      defaults:
+        filters: false
+        filter_groups: false
       display_extenders: {  }
       path: goals
     cache_metadata:

--- a/src/frontend/components/field--goal-type.tsx
+++ b/src/frontend/components/field--goal-type.tsx
@@ -6,6 +6,10 @@ export function FieldGoalType({ field_goal_type }) {
       goalTypeName = "Agency priority goal";
       goalTypeClasses = "bg-primary-vivid";
       break;
+    case "pma":
+      goalTypeName = "PMA";
+      goalTypeClasses = "bg-primary-vivid";
+      break;
     case "strategic":
       goalTypeName = "Strategic goal";
       goalTypeClasses = "bg-base-darkest";
@@ -16,6 +20,10 @@ export function FieldGoalType({ field_goal_type }) {
         break;
     case "plan":
       goalTypeName = "Plan";
+      goalTypeClasses = "bg-base-darkest";
+      break;
+    case "indicator":
+      goalTypeName = "Indicator";
       goalTypeClasses = "bg-base-darkest";
       break;
     default:

--- a/src/frontend/components/field--objectives.tsx
+++ b/src/frontend/components/field--objectives.tsx
@@ -72,13 +72,3 @@ export function FieldObjectives({fieldObjectives} : FieldObjectiveProps) {
     </div>
   );
 }
-
-                  // return(
-                  //   <li key={goal.id} >
-                  //     <Link
-                  //       className={`grid-row flex-no-wrap flex-justify text-no-underline font-sans-md padding-2 text-base-darkest ${linkBorders}`}
-                  //       href={goal.path.alias}>
-                  //         <span>{goal.title}</span>
-                  //         <Icon.NavigateNext size={3} aria-hidden={true} />
-                  //     </Link>
-                  //   </li>

--- a/src/frontend/components/field--period.tsx
+++ b/src/frontend/components/field--period.tsx
@@ -1,15 +1,17 @@
-export function FieldPeriod({field_period}) {
-  if (!field_period?.name) {
+export function FieldPeriod({startTime, endTime}) {
+  if (!startTime) {
     return (
       <span className={`padding-x-105 font-sans-3xs`}>
         default
       </span>
     )
   }
-  let period = field_period.name.startsWith("FY") ? field_period.name.replace(/^[^0-9]+/, '') : field_period.name;
+  const startDate = new Date(startTime);
+  const endDate = new Date(endTime)
+  const dateOptions: Intl.DateTimeFormatOptions = {year: "numeric"}
   return (
     <span className={`padding-x-105 font-sans-3xs`}>
-      {period}
+      {startDate.toLocaleDateString('en-US', dateOptions)}-{endDate.toLocaleDateString('en-US', dateOptions).substr(-2)}
     </span>
   );
 }

--- a/src/frontend/components/indicator-chart.tsx
+++ b/src/frontend/components/indicator-chart.tsx
@@ -1,0 +1,53 @@
+import { LineChart, Line, CartesianGrid, XAxis, YAxis } from 'recharts';
+
+function buildChartData(names, targetValues, actualValues) {
+  let dataArray = [];
+  if(!names) {
+    return [];
+  }
+  names.forEach((name, index) => {
+    dataArray.push({
+      name: name,
+      Targets: targetValues[index],
+      Actuals: actualValues[index],
+    })
+  })
+  return dataArray
+}
+
+const IndicatorChart = ({names, targetValues, values, size}) => {
+  let height = 300;
+  let width = 600;
+  if (!names || !targetValues || !values) {
+    return null;
+  }
+  const data = buildChartData(names, targetValues, values);
+  if (size === "small") {
+    width = 300;
+    height = 150;
+  }
+  return (
+    <div>
+      <LineChart width={width} height={height} data={data}>
+        <Line type="monotone" dataKey="Targets" stroke="#162152" />
+        <Line type="monotone" dataKey="Actuals" stroke="#E41B3C" />
+        <CartesianGrid stroke="#ccc" />
+        {size !== "small" && (
+          <>
+            <XAxis dataKey="name" />
+            <YAxis
+              tickFormatter={(value) =>
+                new Intl.NumberFormat("en-US", {
+                  notation: "compact",
+                  compactDisplay: "short",
+                }).format(value)
+              }
+            />
+          </>
+        )}
+      </LineChart>
+    </div>
+  )
+}
+
+export default IndicatorChart;

--- a/src/frontend/components/node--goal--card.tsx
+++ b/src/frontend/components/node--goal--card.tsx
@@ -22,7 +22,10 @@ export function NodeGoalCard({ goal, ...props }: NodeGoalCardProps) {
         <div className="usa-card__container" >
           <div className="grid-row flex-justify padding-top-1 padding-x-2">
             <FieldGoalType field_goal_type={goalType} />
-            <FieldPeriod field_period={period} />
+            <FieldPeriod
+              startTime={plan.administration.dateRange.start.time}
+              endTime={plan.administration.dateRange.end.time}
+            />
           </div>
           <div className="usa-card__header">
             <h4 className="usa-card__heading">{title}</h4>

--- a/src/frontend/components/node--plan--card.tsx
+++ b/src/frontend/components/node--plan--card.tsx
@@ -9,8 +9,8 @@ interface NodePlanCardProps {
   goal: NodePlanProps
 }
 
-export function NodePlanCard({ goal, ...props }: NodePlanCardProps) {
-  const { title, path, agency, period } = goal;
+export function NodePlanCard({ goal, ...props }: any) {
+  const { title, path, agency, administration } = goal;
   const { acronym: agencyAcronym, logo: agencyLogo, title: agencyTitle } = agency;
   return (
     <div className="goal-card padding-1">
@@ -19,7 +19,10 @@ export function NodePlanCard({ goal, ...props }: NodePlanCardProps) {
         <div className="usa-card__container" >
           <div className="grid-row flex-justify padding-top-1 padding-x-2">
             <FieldGoalType field_goal_type={'plan'} />
-            <FieldPeriod field_period={period} />
+            <FieldPeriod
+              startTime={administration.dateRange.start.time}
+              endTime={administration.dateRange.end.time}
+            />
           </div>
           <div className="usa-card__header">
             <h4 className="usa-card__heading">{title}</h4>

--- a/src/frontend/components/node--plan.tsx
+++ b/src/frontend/components/node--plan.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 import Link from 'next/link'
+import Image from "next/image";
 import { DrupalNode } from "next-drupal";
 import { Icon, Button, ButtonGroup } from "@trussworks/react-uswds";
 import Masonry, { ResponsiveMasonry } from "react-responsive-masonry"
@@ -157,26 +158,32 @@ export function NodePlan({ node, storageData, ...props }: NodePlanProps) {
                   <ul>
                     <ResponsiveMasonry
                       columnsCountBreakPoints={masonryBP}
-                      gutterBreakpoints={{ 350: "12px", 750: "16px", 900: "24px" }}
-                    >
-                      <Masonry>
-                        {field_goals.map((goal) => {
-                          return (
-                            <Link key={goal.id} href={goal.path.alias} className="text-no-underline">
-                              <div className="usa-card__container">
-                                <div className="usa-card__header">
-                                  <h4 className="usa-card__heading ">{goal.title}</h4>
-                                </div>
-                                <div className="usa-card__media">
-                                  <div className="usa-card__img">
-                                    {/* <img
-                                    src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
-                                    alt="A placeholder image"
-                                  /> */}
-                                  </div>
-                                </div>
+                      gutterBreakpoints={{350: "12px", 750: "16px", 900: "24px"}}
+                  >
+                    <Masonry>
+                      {storageData.goals?.map((goal) => {
+                        return(
+                          <Link key={goal.id} href={goal.path} className="text-no-underline">
+                            <div className="usa-card__container">
+                              <div className="usa-card__header">
+                                <h4 className="usa-card__heading ">{goal.title}</h4>
                               </div>
-                            </Link>
+                              <div className="usa-card__media">
+                                {goal?.image?.mediaImage && (
+                                  <div className="usa-card__img">
+                                    <Image
+                                      src={goal.image.mediaImage.variations[0].url}
+                                      width={150}
+                                      height={150}
+                                      alt={goal.image.mediaImage.alt}
+                                      priority
+                                      className="flex-align-self-center"
+                                    />
+                                  </div>
+                                )}
+                              </div>
+                            </div>
+                          </Link>
                           )
                         })}
                       </Masonry>

--- a/src/frontend/components/objective-indicator.tsx
+++ b/src/frontend/components/objective-indicator.tsx
@@ -2,26 +2,11 @@ import { formatDate } from "lib/utils";
 import { LineChart, Line, CartesianGrid, XAxis, YAxis } from 'recharts';
 import { useState } from "react";
 import { Icon } from "@trussworks/react-uswds";
-
-function buildChartData(names, targetValues, actualValues) {
-  let dataArray = [];
-  if(!names) {
-    return [];
-  }
-  names.forEach((name, index) => {
-    dataArray.push({
-      name: name,
-      Targets: targetValues[index],
-      Actuals: actualValues[index],
-    })
-  })
-  return dataArray
-}
+import IndicatorChart from "./indicator-chart";
 
 const ObjectiveIndicator = ({indicator, borders}) => {
   const [open, setOpen] = useState(false)
   const { name, measurements } = indicator;
-  const data = buildChartData(indicator.names, indicator.targetValues, indicator.values);
   return(
     <div className={`objective-indicator text-no-underline font-sans-md text-base-darkest ${borders}`}>
       <button 
@@ -71,15 +56,12 @@ const ObjectiveIndicator = ({indicator, borders}) => {
             </table>
             )}
           </div>
-          <div>
-            <LineChart width={600} height={300} data={data}>
-              <Line type="monotone" dataKey="Targets" stroke="#162152" />
-              <Line type="monotone" dataKey="Actuals" stroke="#E41B3C" />
-              <CartesianGrid stroke="#ccc" />
-              <XAxis dataKey="name" />
-              <YAxis />
-            </LineChart>
-          </div>
+          <IndicatorChart
+            names={indicator.names}
+            values={indicator.values}
+            targetValues={indicator.targetValues}
+            size={"large"}
+          />
           {indicator.notes?.processed && (
             <div dangerouslySetInnerHTML={{ __html: indicator.notes?.processed }} />
           )}

--- a/src/frontend/components/storage--indicator--card.tsx
+++ b/src/frontend/components/storage--indicator--card.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link'
+import { NodePlanProps } from "lib/types";
+import Image from "next/image";
+import AgencyInfoBox from './agency-info-box';
+import { FieldGoalType } from './field--goal-type';
+import { FieldPeriod } from './field--period';
+import IndicatorChart from './indicator-chart';
+
+export function StorageIndicatorCard({ goal, ...props }: any) {
+  const { description, objective } = goal;
+  // console.log(goal)
+  const chartData = objective.indicators.find((indicator) => (indicator.id == goal.id));
+  // console.log(agency);
+  // const { acronym: agencyAcronym, logo: agencyLogo, title: agencyTitle } = agency;
+  return (
+    <div className="goal-card padding-1">
+      <Link href={objective.goal.path}>
+      <div className="padding-y-1 bg-white usa-card margin-bottom-0">
+        <div className="usa-card__container" >
+          <div className="grid-row flex-justify padding-top-1 padding-x-2">
+            <FieldGoalType field_goal_type={'indicator'} />
+            <FieldPeriod
+              startTime={objective.goal.plan.administration.dateRange.start.time}
+              endTime={objective.goal.plan.administration.dateRange.end.time}
+            />
+          </div>
+          <div className="usa-card__header">
+            <h4 className="usa-card__heading">{description.value}</h4>
+          </div>
+          <div className="usa-card__body grid-row flex-column flex-align-center">
+            <IndicatorChart
+              names={chartData.dates}
+              values={chartData.values}
+              targetValues={chartData.targetValues}
+              size={"small"}
+            />
+          </div>
+          <div className="usa-card__footer padding-bottom-1 border-top-2px border-base-lighter">
+            <AgencyInfoBox
+              title={objective.goal.plan.agency.title}
+              logo={objective.goal.plan.agency.logo}
+              acronym={objective.goal.plan.agency.acronym}
+            />
+          </div>
+        </div>
+      </div>
+      </Link>
+    </div>
+  );
+}

--- a/src/frontend/components/storage--indicator--card.tsx
+++ b/src/frontend/components/storage--indicator--card.tsx
@@ -8,10 +8,7 @@ import IndicatorChart from './indicator-chart';
 
 export function StorageIndicatorCard({ goal, ...props }: any) {
   const { description, objective } = goal;
-  // console.log(goal)
   const chartData = objective.indicators.find((indicator) => (indicator.id == goal.id));
-  // console.log(agency);
-  // const { acronym: agencyAcronym, logo: agencyLogo, title: agencyTitle } = agency;
   return (
     <div className="goal-card padding-1">
       <Link href={objective.goal.path}>

--- a/src/frontend/components/usa--header.tsx
+++ b/src/frontend/components/usa--header.tsx
@@ -36,25 +36,5 @@ export function USAHeader() {
         </Link>
       </nav>
     </header>
-    // <Header basic={true} showMobileOverlay={expanded} className="dark-blue-bg">
-    //    <div className="usa-nav-container padding-top-1">
-    //       <div className="usa-navbar">
-    //         <Title>
-              // <Image
-              //   src={PGovLogo}
-              //   width={56}
-              //   height={56}
-              //   alt={"Performance.gov logo"}
-              //   priority
-              //   className=""
-              // />
-    //         </Title>
-    //         <NavMenuButton onClick={onClick} label="Menu" />
-    //       </div>
-    //       <PrimaryNav items={menuItems} mobileExpanded={expanded} onToggleMobileNav={onClick}>
-    //         <Search size="small" onSubmit={(e) => {e.preventDefault(); console.log("Search");}} />
-    //       </PrimaryNav>
-    //     </div>
-    // </Header>
   );
 }

--- a/src/frontend/components/view--goal-facets.tsx
+++ b/src/frontend/components/view--goal-facets.tsx
@@ -9,7 +9,7 @@ const ViewGoalFacets = ({handleSearch, handleClose}) => {
     fetch(url)
       .then((res) => res.json())
       .then((data) => setFacets(data));
-  }, []);
+  }, [url]);
 
   const [checkedFacets, setCheckedFacets] = useState([])
 

--- a/src/frontend/components/view--goal-search.tsx
+++ b/src/frontend/components/view--goal-search.tsx
@@ -31,7 +31,7 @@ const renderCard = (goal: any) => {
 export default function GoalsSearchView({ filters, goals, total, description }: ViewGoalSearch) {
   const offsetAmount = 15;
   const [fulltext, setFulltext] = useState(filters[0]?.value ? filters[0].value : "");
-  const [administration, setAdministration] = useState("53");
+  const [administration, setAdministration] = useState("45");
   const [totalResults, setTotalResults] = useState(total)
   const [displayGoals, setDisplayGoals] = useState(goals);
   const [viewType, setViewType] = useState([]);
@@ -68,7 +68,7 @@ export default function GoalsSearchView({ filters, goals, total, description }: 
 
   const masonryBP = filtersOpen ? {350: 1, 750: 2, 1400: 3} : {350: 1, 750: 2, 1060: 3, 1400: 4};
   return (
-    <div>
+    <div className="view--goal-search">
       <div className="grid-row flex-column flex-align-center hero text-white padding-y-5">
         <h1 className="font-heading-2xl">{description}</h1>
         <p className="font-sans-lg margin-y-0">Smart Strategy. Strong Execution.</p>

--- a/src/frontend/components/view--goal-search.tsx
+++ b/src/frontend/components/view--goal-search.tsx
@@ -31,7 +31,7 @@ const renderCard = (goal: any) => {
 export default function GoalsSearchView({ filters, goals, total, description }: ViewGoalSearch) {
   const offsetAmount = 15;
   const [fulltext, setFulltext] = useState(filters[0]?.value ? filters[0].value : "");
-  const [administration, setAdministration] = useState("45");
+  const [administration, setAdministration] = useState("53");
   const [totalResults, setTotalResults] = useState(total)
   const [displayGoals, setDisplayGoals] = useState(goals);
   const [viewType, setViewType] = useState([]);

--- a/src/frontend/components/view--goal-search.tsx
+++ b/src/frontend/components/view--goal-search.tsx
@@ -68,7 +68,7 @@ export default function GoalsSearchView({ filters, goals, total, description }: 
 
   const masonryBP = filtersOpen ? {350: 1, 750: 2, 1400: 3} : {350: 1, 750: 2, 1060: 3, 1400: 4};
   return (
-    <div className="view--goal-search">
+    <div>
       <div className="grid-row flex-column flex-align-center hero text-white padding-y-5">
         <h1 className="font-heading-2xl">{description}</h1>
         <p className="font-sans-lg margin-y-0">Smart Strategy. Strong Execution.</p>

--- a/src/frontend/lib/graphqlQueries.ts
+++ b/src/frontend/lib/graphqlQueries.ts
@@ -43,7 +43,20 @@ export const graphqlQueries = {
                           targetValue
                           value
                           status
-
+                          period {
+                            ... on StoragePeriod {
+                              id
+                              name
+                              dateRange {
+                                end {
+                                  time
+                                }
+                                start {
+                                  time
+                                }
+                              }
+                            }
+                          }
                         }
                       }
                     }

--- a/src/frontend/lib/graphqlQueries.ts
+++ b/src/frontend/lib/graphqlQueries.ts
@@ -111,6 +111,21 @@ export const graphqlQueries = {
               goals {
                 ... on NodeGoal {
                   id
+                  title
+                  path
+                  image {
+                    ... on MediaImage {
+                      id
+                      name
+                      mediaImage {
+                        alt
+                        title
+                        variations(styles: THIRD1X1) {
+                          url
+                        }
+                      }
+                    }
+                  }
                   objectives {
                     ... on NodeObjective {
                       id
@@ -159,12 +174,15 @@ export const graphqlQueries = {
     fulltext: string | string[],
     facets: string | string[],
     administration: string | string[],
+    type: string | string[],
   ) =>
     `query GoalsQuery {
       goalsGraphql1(filter: {
         aggregated_field: "${fulltext}",
         Topics: ${JSON.stringify(facets)},
-        Administration: ${administration}
+        aggregated_administration: ${JSON.stringify(administration)},
+        aggregated_type: ${JSON.stringify(type)},
+        storage_topic_name: ${JSON.stringify(facets)}
       }) {
     pageInfo {
       total
@@ -229,6 +247,20 @@ export const graphqlQueries = {
         plan {
           ... on NodePlan {
             id
+            administration {
+              ... on StorageAdministration {
+                id
+                name
+                dateRange {
+                  end {
+                    time
+                  }
+                  start {
+                    time
+                  }
+                }
+              }
+            }
             agency {
               ... on NodeAgency {
                 id
@@ -258,6 +290,20 @@ export const graphqlQueries = {
         title
         id
         path
+        administration {
+          ... on StorageAdministration {
+            id
+            name
+            dateRange {
+              end {
+                time
+              }
+              start {
+                time
+              }
+            }
+          }
+        }
         agency {
           ... on NodeAgency {
             id
@@ -281,9 +327,70 @@ export const graphqlQueries = {
           }
         }
       }
+      ...on StorageIndicator {
+        id
+        description {
+          value
+        }
+        objective {
+          ... on NodeObjective {
+            id
+            goal {
+              ... on NodeGoal {
+                id
+                path
+                plan {
+                  ... on NodePlan {
+                    id
+                    administration {
+                      ... on StorageAdministration {
+                        id
+                        name
+                        dateRange {
+                          end {
+                            time
+                          }
+                          start {
+                            time
+                          }
+                        }
+                      }
+                    }
+                    agency {
+                      ... on NodeAgency {
+                        id
+                        acronym
+                        logo {
+                          ... on MediaImage {
+                            id
+                            name
+                            mediaImage {
+                              url
+                            }
+                          }
+                        }
+                        title
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            indicators {
+              ... on StorageIndicator {
+                id
+                name
+                values
+                targetValues
+                dates
+              }
+            }
+          }
+        }
+      }
     }
-  }
-    }`,
+    }
+  }`,
   taxonomyTopics: () =>
     `
     query getTopics {

--- a/src/frontend/lib/graphqlQueries.ts
+++ b/src/frontend/lib/graphqlQueries.ts
@@ -182,7 +182,6 @@ export const graphqlQueries = {
         Topics: ${JSON.stringify(facets)},
         aggregated_administration: ${JSON.stringify(administration)},
         aggregated_type: ${JSON.stringify(type)},
-        storage_topic_name: ${JSON.stringify(facets)}
       }) {
     pageInfo {
       total

--- a/src/frontend/pages/[...slug].tsx
+++ b/src/frontend/pages/[...slug].tsx
@@ -88,8 +88,9 @@ export async function getStaticProps(
       "field_agency.field_logo",
       "field_agency.field_logo.field_media_image",
       "field_goals.field_objectives",
+      "field_goals.field_image.field_media_image"
     ]);
-    params.addFields("node--goal", ["title", "field_objectives", "path"]);
+    params.addFields("node--goal", ["title", "field_objectives", "path", "field_image"]);
     params.addFields("node--objective", ["title", "body", "field_indicators"]);
   }
 

--- a/src/frontend/pages/api/goal-search.ts
+++ b/src/frontend/pages/api/goal-search.ts
@@ -25,11 +25,17 @@ export default async function handler(
   const administration = req.query.administration
     ? req.query.administration
     : "53";
+  const type = req.query.type ? req.query.type : [];
   const response = await drupal.fetch(graphqlUrl.toString(), {
     method: "POST",
     withAuth: true, // Make authenticated requests using OAuth.
     body: JSON.stringify({
-      query: graphqlQueries.goalsView(fulltext, facetsList, administration),
+      query: graphqlQueries.goalsView(
+        fulltext,
+        facetsList,
+        administration,
+        type,
+      ),
     }),
   });
   const { data } = await response.json();

--- a/src/frontend/pages/index.tsx
+++ b/src/frontend/pages/index.tsx
@@ -20,9 +20,10 @@ export const getStaticProps = async () => {
     method: "POST",
     withAuth: true, // Make authenticated requests using OAuth.
     body: JSON.stringify({
-      query: graphqlQueries.goalsView("", [], "53"),
+      query: graphqlQueries.goalsView("", [], "53",[]),
     }),
   });
+  
   const { data } = await response.json();
   return {
     props: {

--- a/src/frontend/styles/style.scss
+++ b/src/frontend/styles/style.scss
@@ -72,6 +72,7 @@ a {
 
 .view--goal-search .side-bar {
   padding: 0 24px 24px;
+  border-right: 1px solid $goals-gray;
   position: absolute;
   top: 0;
   left: 0;

--- a/src/frontend/styles/style.scss
+++ b/src/frontend/styles/style.scss
@@ -68,6 +68,10 @@ a {
 .filter-bar {
   padding: 0 24px 24px;
   border-right: 1px solid $goals-gray;
+}
+
+.view--goal-search .side-bar {
+  padding: 0 24px 24px;
   position: absolute;
   top: 0;
   left: 0;

--- a/src/frontend/styles/style.scss
+++ b/src/frontend/styles/style.scss
@@ -68,11 +68,6 @@ a {
 .filter-bar {
   padding: 0 24px 24px;
   border-right: 1px solid $goals-gray;
-}
-
-.view--goal-search .side-bar {
-  padding: 0 24px 24px;
-  border-right: 1px solid $goals-gray;
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
This branch updates the search api to use an aggregated field for administration so the included indicators will also be filtered. To test, you will need to pull code, import config, run cron, and then build the frontend. 

The one thing this does not do is get plans and indicators to work with the facets. I don't think that is going to be possible with our current data structure. There is no way to an aggregated field of topics from how nested everything is. 