### PR TITLE
Feature/pgov 578 2025 29 period

### DIFF
--- a/config/field.storage.node.field_goal_type.yml
+++ b/config/field.storage.node.field_goal_type.yml
@@ -24,7 +24,7 @@ settings:
       value: Strategic
       label: 'Strategic Goal'
     -
-      value: pma
+      value: PMA
       label: PMA
   allowed_values_function: ''
 module: options

--- a/web/modules/custom/pgov_migrate/content/storage/1a1fe0e6-b7ca-4000-aa5f-14790a23a087.yml
+++ b/web/modules/custom/pgov_migrate/content/storage/1a1fe0e6-b7ca-4000-aa5f-14790a23a087.yml
@@ -1,0 +1,32 @@
+_meta:
+  version: '1.0'
+  entity_type: storage
+  uuid: 1a1fe0e6-b7ca-4000-aa5f-14790a23a087
+  bundle: period
+  default_langcode: en
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  user_id:
+    -
+      target_id: 1
+  name:
+    -
+      value: 2025-2029
+  created:
+    -
+      value: 1739236553
+  revision_translation_affected:
+    -
+      value: true
+  field_date_range:
+    -
+      value: '2025-01-20'
+      end_value: '2029-01-19'
+  field_duration:
+    -
+      value: other


### PR DESCRIPTION
This change has ALREADY BEEN APPLIED on the live site, and the PR will cause the changes to persist on future migrations.

Goals related to the Trump 47 plan were missing:
* Goal type (PMA)
* Dates (time period relationship)

This PR:
* Updates the text value for PMA goal types such that the migration will work (and will look better when shortened, as `PMA` instead of `pma`)
* Adds a 2025-29 Time period so that the goals have something to match.

![image](https://github.com/user-attachments/assets/bbbe0c00-2d0e-4f90-a546-891551e28b27)
